### PR TITLE
Feature/129864 exibir toast com msg de erro

### DIFF
--- a/src/components/login/LoginForm/index.tsx
+++ b/src/components/login/LoginForm/index.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 
 import ClosedEye from "@/assets/icons/CloseEye";
 import OpenEye from "@/assets/icons/OpenEye";
+import { AlertCircleIcon } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -17,14 +18,20 @@ import {
     FormMessage,
 } from "@/components/ui/form";
 import { Input, InputMask } from "@/components/ui/input";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 import formSchema, { FormDataLogin } from "./schema";
 import useView from "./view";
 import BackgroundForm from "../BackgroundForm";
+import { PERFIL_NOT_PERMISSION_ERROR_MESSAGE } from "@/const";
 
 export default function LoginForm() {
     const [showPassword, setShowPassword] = useState<boolean>(false);
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
+    const [hasError, setHasError] = useState<boolean>(false);
+
+    // Guarda os valores anteriores para detectar mudanças reais
+    const previousValues = useRef({ rf: "", password: "" });
 
     const form = useForm<FormDataLogin>({
         resolver: zodResolver(formSchema),
@@ -36,6 +43,37 @@ export default function LoginForm() {
     });
 
     const { onSubmit, isPending } = useView();
+
+    // Watch para os campos RF e password
+    const watchedFields = form.watch(["rf", "password"]);
+    const [rf, password] = watchedFields;
+
+    // Effect para esconder o alert quando qualquer campo for alterado
+    useEffect(() => {
+        if (hasError) {
+            // Verifica se houve mudança real nos campos
+            const rfChanged = rf !== previousValues.current.rf;
+            const passwordChanged =
+                password !== previousValues.current.password;
+
+            if (rfChanged || (passwordChanged && password !== "")) {
+                setErrorMessage(null);
+                setHasError(false);
+            }
+        }
+
+        // Atualiza os valores anteriores
+        previousValues.current = { rf, password };
+    }, [rf, password, hasError]);
+
+    // Função personalizada para o submit
+    const handleSubmit = (values: FormDataLogin) => {
+        onSubmit(values, (errorMsg: string) => {
+            setErrorMessage(errorMsg);
+            setHasError(true);
+            form.setValue("password", ""); // Limpa senha
+        });
+    };
 
     return (
         <div className="min-h-screen relative overflow-hidden">
@@ -52,13 +90,32 @@ export default function LoginForm() {
                                 tenha mais autonomia em suas atividades diárias.
                             </p>
                         </div>
+                        <div className="mb-8">
+                            {errorMessage && (
+                                <Alert
+                                    variant="destructive"
+                                    className="bg-[#ffe9e9] [&>svg]:size-6"
+                                >
+                                    <AlertCircleIcon />
+                                    {errorMessage !==
+                                        PERFIL_NOT_PERMISSION_ERROR_MESSAGE && (
+                                        <AlertTitle className="font-bold text-[#111827]">
+                                            Vamos tentar de novo?
+                                        </AlertTitle>
+                                    )}
+                                    <AlertDescription>
+                                        <p className="text-[#6b7280] !leading-4 -mt-1">
+                                            {errorMessage}
+                                        </p>
+                                    </AlertDescription>
+                                </Alert>
+                            )}
+                        </div>
 
                         <Form {...form}>
                             <form
                                 className="space-y-4 md:space-y-3"
-                                onSubmit={form.handleSubmit((values) =>
-                                    onSubmit(values, setErrorMessage)
-                                )} // Passando setErrorMessage para onSubmit
+                                onSubmit={form.handleSubmit(handleSubmit)}
                             >
                                 <FormField
                                     control={form.control}
@@ -126,12 +183,6 @@ export default function LoginForm() {
                                         )}
                                     </button>
                                 </div>
-
-                                {errorMessage && (
-                                    <div className="text-red-600 text-sm font-medium text-center">
-                                        {errorMessage}
-                                    </div>
-                                )}
 
                                 {/* Link esqueceu senha */}
                                 <div className="text-right">

--- a/src/components/login/LoginForm/schema.ts
+++ b/src/components/login/LoginForm/schema.ts
@@ -1,13 +1,19 @@
 import { z } from "zod";
 
+import {
+  RF_ERROR_MESSAGE,
+  PASSWORD_ERROR_MESSAGE,
+  RF_FORMAT_ERROR_MESSAGE
+} from "@/const";
+
 const formSchema = z.object({
     rf: z
         .string()
-        .min(1, "RF é obrigatório")
-        .max(8, "Formato de RF inválido"),
+        .min(1, RF_ERROR_MESSAGE)
+        .max(8, RF_FORMAT_ERROR_MESSAGE),
     password: z
         .string()
-        .min(1, "Senha é obrigatória")
+        .min(1, PASSWORD_ERROR_MESSAGE)
 });
 
 export type FormDataLogin = z.infer<typeof formSchema>;

--- a/src/components/login/LoginForm/view.test.ts
+++ b/src/components/login/LoginForm/view.test.ts
@@ -20,7 +20,7 @@ vi.mock("react", async () => {
 import { authenticate } from "@/lib/actions";
 
 describe("useView", () => {
-    const setErrorMessage = vi.fn();
+    const onError = vi.fn(); // Mudou de setErrorMessage para onError
     const values = {
         rf: "12345678",
         password: "admin123",
@@ -30,28 +30,44 @@ describe("useView", () => {
         vi.clearAllMocks();
     });
 
-    it("chama setErrorMessage(null) quando autenticação é bem-sucedida", async () => {
+    it("NÃO chama onError quando autenticação é bem-sucedida", async () => {
         (authenticate as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
 
         const { onSubmit } = useView();
 
-        await onSubmit(values, setErrorMessage);
+        await onSubmit(values, onError);
 
         expect(authenticate).toHaveBeenCalled();
-        expect(setErrorMessage).toHaveBeenCalledWith(null);
+        expect(onError).not.toHaveBeenCalled(); // Mudou: não deve chamar quando sucesso
     });
 
-    it("chama setErrorMessage com string de erro se for retornado", async () => {
+    it("chama onError com string de erro quando autenticação falha", async () => {
         (authenticate as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
             "Invalid credentials."
         );
 
         const { onSubmit } = useView();
 
-        await onSubmit(values, setErrorMessage);
+        await onSubmit(values, onError);
 
         expect(authenticate).toHaveBeenCalled();
-        expect(setErrorMessage).toHaveBeenCalledWith("Invalid credentials.");
+        expect(onError).toHaveBeenCalledWith("Invalid credentials."); // Mantém o mesmo teste
     });
 
+    it("chama authenticate com FormData correto", async () => {
+        (authenticate as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+
+        const { onSubmit } = useView();
+
+        await onSubmit(values, onError);
+
+        // Verifica se authenticate foi chamado com FormData
+        expect(authenticate).toHaveBeenCalledWith(undefined, expect.any(FormData));
+
+        // Verifica o conteúdo do FormData
+        const callArgs = (authenticate as ReturnType<typeof vi.fn>).mock.calls[0];
+        const formData = callArgs[1] as FormData;
+        expect(formData.get("rf")).toBe("12345678");
+        expect(formData.get("password")).toBe("admin123");
+    });
 });

--- a/src/components/login/LoginForm/view.ts
+++ b/src/components/login/LoginForm/view.ts
@@ -7,10 +7,8 @@ export default function useLoginView() {
 
     async function onSubmit(
         values: FormDataLogin,
-        setErrorMessage: (msg: string | null) => void
+        onError: (errorMsg: string) => void
     ) {
-        setErrorMessage(null); // Limpa mensagens de erro anteriores
-
         startTransition(async () => {
             const formData = new FormData();
             formData.append("rf", values.rf);
@@ -19,7 +17,7 @@ export default function useLoginView() {
             const error = await authenticate(undefined, formData);
 
             if (error) {
-                setErrorMessage(error);
+               onError(error); // Chama callback quando há erro
             }
         });
     }

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/const.ts
+++ b/src/const.ts
@@ -3,6 +3,8 @@ export const PASSWORD_REGEX_PATTERN =
     /^[^ÁáÂâÀàÅåÃãÄäÉéÊêÈèËëÍíÎîÌìÏïÓóÔôÒòÕõÖöÚúÛûÙùÜüÇçÑñÝý]*$/;
 
 // VALIDATION MESSAGE
-export const GENERIC_INPUT_ERROR_MESSAGE = "Preenchimento incorreto";
-export const REQUIRED_INPUT_ERROR_MESSAGE = "Campo obrigatório";
-export const PASSWORD_ERROR_MESSAGE = "A senha deve ser sem acento";
+export const PASSWORD_ERROR_MESSAGE = "Senha é obrigatória";
+export const RF_ERROR_MESSAGE = "RF é obrigatório";
+export const RF_FORMAT_ERROR_MESSAGE = "Formato de RF inválido";
+export const PERFIL_NOT_FOUND_ERROR_MESSAGE = "Não encontramos um perfil com essas informações. Por favor, tente novamente.";
+export const PERFIL_NOT_PERMISSION_ERROR_MESSAGE = "Desculpe! mas o acesso ao Autosserviço é restrito a perfis específicos.";

--- a/src/lib/auth/__tests__/logic.test.ts
+++ b/src/lib/auth/__tests__/logic.test.ts
@@ -53,14 +53,14 @@ describe("authorizeUser", () => {
     mockedLogin.mockResolvedValue({ status: 401 });
     await expect(
       authorizeUser({ rf: "123", password: "errada" })
-    ).rejects.toThrow("Senha inválida!");
+    ).rejects.toThrow("Não encontramos um perfil com essas informações. Por favor, tente novamente.");
   });
 
   it("lança erro se não tiver nome e tiver detail", async () => {
-    mockedLogin.mockResolvedValue({ detail: "Usuário não encontrado" });
+    mockedLogin.mockResolvedValue({ detail: "Não encontramos um perfil com essas informações. Por favor, tente novamente." });
     await expect(
       authorizeUser({ rf: "123", password: "qualquer" })
-    ).rejects.toThrow("Usuário não encontrado!");
+    ).rejects.toThrow("Não encontramos um perfil com essas informações. Por favor, tente novamente.");
   });
 
   it("lança erro se acesso não for permitido", async () => {
@@ -68,7 +68,7 @@ describe("authorizeUser", () => {
     mockedPermissao.mockReturnValue(false);
     await expect(
       authorizeUser({ rf: "123", password: "qualquer" })
-    ).rejects.toThrow("Você não tem permissão para acessar este sistema.");
+    ).rejects.toThrow("Desculpe! mas o acesso ao Autosserviço é restrito a perfis específicos.");
   });
 
   it("lança erro se nome ou login estiverem ausentes", async () => {

--- a/src/lib/auth/logic.ts
+++ b/src/lib/auth/logic.ts
@@ -3,8 +3,9 @@ import { temPermissaoDeAcesso } from "./validacoes";
 import type { User, Session } from "next-auth";
 import type { JWT } from "next-auth/jwt";
 
-// Necessário isolar a lógica de autenticação para atingir a cobertura de testes
+import {PERFIL_NOT_FOUND_ERROR_MESSAGE, PERFIL_NOT_PERMISSION_ERROR_MESSAGE} from "@/const";
 
+// Necessário isolar a lógica de autenticação para atingir a cobertura de testes
 export async function authorizeUser(
     credentials: Partial<Record<"rf" | "password", unknown>> | undefined
 ): Promise<User | null> {
@@ -17,12 +18,8 @@ export async function authorizeUser(
         senha: credentials.password as string,
     });
 
-    if (loginResponse.status === 401) {
-        throw new Error("Senha inválida!");
-    }
-
-    if (!loginResponse.nome && loginResponse.detail) {
-        throw new Error("Usuário não encontrado!");
+    if (loginResponse.status === 401 || (!loginResponse.nome && loginResponse.detail)) {
+        throw new Error(PERFIL_NOT_FOUND_ERROR_MESSAGE);
     }
 
     const acessoPermitido = temPermissaoDeAcesso(
@@ -30,7 +27,7 @@ export async function authorizeUser(
     );
 
     if (!acessoPermitido) {
-        throw new Error("Você não tem permissão para acessar este sistema.");
+        throw new Error(PERFIL_NOT_PERMISSION_ERROR_MESSAGE);
     }
 
     if (!loginResponse.nome || !loginResponse.login) {


### PR DESCRIPTION
Esse PR:

- Melhora código implementando constantes reutilizáveis para mensagens de erros
- Refatora View de Login para atender os critérios de aceite da história
- Implementa os testes
- Implementa exibir mensagem de erro ao não localizar usuário

Tarefa: [AB#129864](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/129864)