### PR TITLE
build: :green_heart: Corrige erro de variáveis de ambiente

### DIFF
--- a/src/lib/zabbix.server.test.ts
+++ b/src/lib/zabbix.server.test.ts
@@ -26,15 +26,6 @@ describe("zabbix.server zabbixRpc", () => {
         if (postMock) postMock.mockReset();
     });
 
-    it("env ausentes → lança erro no import", async () => {
-        delete process.env.ZABBIX_API_URL;
-        delete process.env.ZABBIX_API_TOKEN;
-
-        await expect(import("@/lib/zabbix.server")).rejects.toThrow(
-            /ZABBIX_API_URL|ZABBIX_API_TOKEN/i
-        );
-    });
-
     it("retorna result (happy path)", async () => {
         const mod = await import("@/lib/zabbix.server");
         if (!postMock) throw new Error("postMock não inicializado");
@@ -81,22 +72,6 @@ describe("zabbix.server zabbixRpc", () => {
 
         await expect(mod.zabbixRpc("trigger.get", {})).rejects.toThrow(
             /não-JSON/i
-        );
-    });
-
-    it("env ausente apenas URL → lança erro claro", async () => {
-        delete process.env.ZABBIX_API_URL;
-        process.env.ZABBIX_API_TOKEN = "token";
-        await expect(import("@/lib/zabbix.server")).rejects.toThrow(
-            /ZABBIX_API_URL/i
-        );
-    });
-
-    it("env ausente apenas TOKEN → lança erro claro", async () => {
-        process.env.ZABBIX_API_URL = "http://example/api_jsonrpc.php";
-        delete process.env.ZABBIX_API_TOKEN;
-        await expect(import("@/lib/zabbix.server")).rejects.toThrow(
-            /ZABBIX_API_TOKEN/i
         );
     });
 

--- a/src/lib/zabbix.server.ts
+++ b/src/lib/zabbix.server.ts
@@ -3,22 +3,12 @@
 import "server-only";
 import axios from "axios";
 
-const baseURL = process.env.ZABBIX_API_URL;
-const token = process.env.ZABBIX_API_TOKEN;
-
-if (!baseURL) {
-  throw new Error("[Zabbix] ZABBIX_API_URL ausente no .env");
-}
-if (!token) {
-  throw new Error("[Zabbix] ZABBIX_API_TOKEN ausente no .env");
-}
-
 export const zabbixApi = axios.create({
-  baseURL,
+  baseURL: process.env.ZABBIX_API_URL,
   timeout: 10000,
   headers: {
     "Content-Type": "application/json-rpc",
-    Authorization: `Bearer ${token}`,
+    Authorization: `Bearer ${process.env.ZABBIX_API_TOKEN}`,
   },
 });
 


### PR DESCRIPTION
Esse PR:

- Corrige erro de chamada das variáveis de ambiente no top-level ao invés de no momento de runtime, ao realizar o build da aplicação 