### PR TITLE
Feature/133816 componente saude dos servidores filas

### DIFF
--- a/src/actions/disponibilidade-dos-ambientes.ts
+++ b/src/actions/disponibilidade-dos-ambientes.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import { zabbixRpc } from "@/lib/zabbix.server";
+import { formatDDMMYYYY_HHMM_FromSeconds } from "@/lib/utils";
 
 export type ProducaoStatus = {
   available: boolean;
@@ -15,18 +16,6 @@ const RECENT_WINDOW_MS = Number(
 );
 
 type Trigger = { lastchange: string; value: string };
-
-function formatDDMMYYYY_HHMM_FromSeconds(seconds?: number): string | undefined {
-  if (!seconds || !isFinite(seconds)) return undefined;
-  const d = new Date(seconds * 1000);
-  if (isNaN(d.getTime())) return undefined;
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const yyyy = d.getFullYear();
-  const hh = String(d.getHours()).padStart(2, "0");
-  const mi = String(d.getMinutes()).padStart(2, "0");
-  return `${dd}/${mm}/${yyyy} ${hh}:${mi}`;
-}
 
 export async function getDisponibilidadeDosAmbientesProducao(
   projectName: string,

--- a/src/actions/saude-dos-servidores.test.ts
+++ b/src/actions/saude-dos-servidores.test.ts
@@ -1,0 +1,371 @@
+// tests/actions/disponibilidade-dos-ambientes.test.ts
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const zabbixRpcMock = vi.fn();
+
+vi.mock("@/lib/zabbix.server", () => ({
+    __esModule: true,
+    zabbixRpc: zabbixRpcMock,
+}));
+
+// helper para formatar exatamente como a action (dd/mm/aaaa HH:mm)
+const fmt = (sec: number) => {
+    const d = new Date(sec * 1000);
+    const dd = String(d.getDate()).padStart(2, "0");
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const yyyy = d.getFullYear();
+    const hh = String(d.getHours()).padStart(2, "0");
+    const mi = String(d.getMinutes()).padStart(2, "0");
+    return `${dd}/${mm}/${yyyy} ${hh}:${mi}`;
+};
+
+describe("getSaudeDosServidoresFilas", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        zabbixRpcMock.mockReset();
+        process.env.ZABBIX_DEFAULT_HOST = "Zabbix server";
+        process.env.ZABBIX_RECENT_WINDOW_MS = String(24 * 60 * 60 * 1000); // 24h
+        // fixa o tempo para condições de janela consistentes
+        vi.setSystemTime(new Date("2025-08-27T12:00:00.000Z"));
+    });
+
+    it("sem triggers → disponível / sem incidentes recentes", async () => {
+        zabbixRpcMock.mockResolvedValueOnce([]);
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas("PRD - RabbitMQ");
+        expect(res).toEqual({
+            available: true,
+            incidents_recent: false,
+            message: "Sem incidentes recentes",
+        });
+
+        const calledParams = zabbixRpcMock.mock.calls[0][1];
+        expect(calledParams.filter.description).toEqual("PRD - RabbitMQ");
+    });
+
+    it("trigger ativo (value=1) → indisponível / incidentes ativos", async () => {
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "1", lastchange: "1751304488" },
+        ]);
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas("PRD - RabbitMQ");
+        expect(res.available).toBe(false);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toMatch(/incidentes ativos/i);
+    });
+
+    it("trigger ok porém lastchange dentro da janela → houve incidentes recentes", async () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "0", lastchange: String(nowSec) },
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas("PRD - RabbitMQ");
+        expect(res.available).toBe(true);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toMatch(/Houve incidentes recentes/i);
+    });
+
+    it("trigger ok e lastchange fora da janela → sem incidentes recentes", async () => {
+        const longAgo = Math.floor((Date.now() - 10 * 24 * 3600 * 1000) / 1000);
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "0", lastchange: String(longAgo) },
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas("PRD - RabbitMQ");
+        expect(res.available).toBe(true);
+        expect(res.incidents_recent).toBe(false);
+        expect(res.message).toMatch(/Sem incidentes recentes/i);
+    });
+
+    // it("honra host passado por parâmetro", async () => {
+    //     zabbixRpcMock.mockResolvedValueOnce([]);
+
+    //     const { getSaudeDosServidoresFilas } = await import(
+    //         "@/actions/saude-dos-servidores"
+    //     );
+    //     await getSaudeDosServidoresFilas(
+    //         "PRD - RabbitMQ",
+    //         "Meu Host"
+    //     );
+    //     const calledParams = zabbixRpcMock.mock.calls[0][1];
+    //     expect(calledParams.filter.host).toEqual(["Meu Host"]);
+    // });
+
+    it("retorno undefined do zabbixRpc → trata como sem triggers", async () => {
+        zabbixRpcMock.mockResolvedValueOnce(undefined);
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas("PRD - RabbitMQ");
+        expect(res).toEqual({
+            available: true,
+            incidents_recent: false,
+            message: "Sem incidentes recentes",
+        });
+    });
+
+    it("quando host efetivo estiver vazio, filtro NÃO inclui host (ramo alternativo)", async () => {
+        // Com a versão atual da action, se host efetivo for falsy, omitimos o filtro 'host'
+        process.env.ZABBIX_DEFAULT_HOST = ""; // sem fallback
+        zabbixRpcMock.mockResolvedValueOnce([]);
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        await getSaudeDosServidoresFilas("PRD - RabbitMQ", "");
+        const calledParams = zabbixRpcMock.mock.calls[0][1];
+        expect(calledParams.filter.description).toEqual("PRD - RabbitMQ");
+    });
+
+    it("sem triggers → sem incidents_recent e sem lastIncidentAt", async () => {
+        zabbixRpcMock.mockResolvedValueOnce([]);
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+        expect(res).toEqual({
+            available: true,
+            incidents_recent: false,
+            message: "Sem incidentes recentes",
+        });
+        expect(res.lastIncidentAt).toBeUndefined();
+    });
+
+    it("incidente ATIVO (value=1) → lastIncidentAt do mais recente ativo", async () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const active1 = nowSec - 3600; // 1h atrás
+        const active2 = nowSec - 60 * 10; // 10min atrás (mais recente)
+
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "1", lastchange: String(active1) },
+            { value: "1", lastchange: String(active2) },
+            { value: "0", lastchange: String(nowSec - 60 * 30) },
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        expect(res.available).toBe(false);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toBe("Há incidentes ativos");
+        expect(res.lastIncidentAt).toBe(fmt(active2));
+    });
+
+    it("sem ativo, mas recente dentro da janela → lastIncidentAt do mais recente recente", async () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const recent1 = nowSec - 60 * 50; // 50min atrás
+        const recent2 = nowSec - 60 * 5; // 5min atrás (mais recente)
+        const old = nowSec - 60 * 60 * 48; // 48h atrás (fora da janela)
+
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "0", lastchange: String(recent1) },
+            { value: "0", lastchange: String(recent2) },
+            { value: "0", lastchange: String(old) },
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        expect(res.available).toBe(true);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toBe("Houve incidentes recentes");
+        expect(res.lastIncidentAt).toBe(fmt(recent2));
+    });
+
+    it("sem ativo e todos fora da janela → sem incidents_recent e sem lastIncidentAt", async () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const old1 = nowSec - 60 * 60 * 30; // 30h atrás
+        const old2 = nowSec - 60 * 60 * 72; // 72h atrás
+
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "0", lastchange: String(old1) },
+            { value: "0", lastchange: String(old2) },
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        expect(res).toMatchObject({
+            available: true,
+            incidents_recent: false,
+            message: "Sem incidentes recentes",
+        });
+        expect(res.lastIncidentAt).toBeUndefined();
+    });
+
+    // ✅ NOVO: ativos têm precedência sobre recentes
+    it("quando há triggers ativos e recentes, prevalece o estado 'ativo' e a data do ativo mais recente", async () => {
+        const nowSec = Math.floor(Date.now() / 1000);
+        const recent = nowSec - 60 * 2; // 2 min (OK)
+        const active = nowSec - 60 * 1; // 1 min (ATIVO, deve vencer)
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "0", lastchange: String(recent) },
+            { value: "1", lastchange: String(active) },
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        expect(res.available).toBe(false);
+        expect(res.message).toBe("Há incidentes ativos");
+        expect(res.lastIncidentAt).toBe(fmt(active));
+    });
+
+    it("usa o valor DEFAULT de RECENT_WINDOW_MS quando a env não está definida (fallback do ??)", async () => {
+        // este teste precisa reimportar o módulo SEM a env definida
+        vi.resetModules();
+        delete process.env.ZABBIX_RECENT_WINDOW_MS; // força fallback
+        process.env.ZABBIX_DEFAULT_HOST = "Zabbix server";
+
+        const nowSec = Math.floor(Date.now() / 1000);
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "0", lastchange: String(nowSec) }, // recente dentro da janela default (24h)
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        expect(res.available).toBe(true);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toMatch(/Houve incidentes recentes/i);
+    });
+
+    it("ativo com lastchange enorme (finite) gera Invalid Date → lastIncidentAt fica undefined (cobre isNaN path)", async () => {
+        // Número finito mas tão grande que new Date(seconds*1000) vira Invalid Date
+        const huge = 9e20; // isFinite(huge) === true, mas new Date(huge*1000) => Invalid Date
+
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "1", lastchange: String(huge) },
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        expect(res.available).toBe(false);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toBe("Há incidentes ativos");
+        // 🔎 aqui cobrimos formatDDMMYYYY_HHMM_FromSeconds com Invalid Date
+        expect(res.lastIncidentAt).toBeUndefined();
+    });
+
+    it("ATIVO com lastchange inválido/ausente → fallback 0 e lastIncidentAt undefined", async () => {
+        // Ambos os ativos têm lastchange que vira 0/NaN → Math.max(...)=0 → formatter cai no ramo !seconds
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "1", lastchange: "" as string }, // Number("") === 0
+            { value: "1", lastchange: "NaN" as string }, // Number("NaN") => NaN -> || 0
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        expect(res.available).toBe(false);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toBe("Há incidentes ativos");
+        // ✅ cobre formatter (!seconds) e caminho de ativos com data indefinida (linha ~56)
+        expect(res.lastIncidentAt).toBeUndefined();
+    });
+
+    it("SEM ativos, mas 'recentes' com lastchange gigante → incidents_recent=true e lastIncidentAt undefined (Invalid Date)", async () => {
+        // Usamos um 'seconds' enorme para ficar 'dentro' da janela (diferença negativa) mas quebrar o Date
+        const huge = 9e20; // isFinite(huge) === true; new Date(huge*1000) => Invalid Date
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "0", lastchange: String(huge) }, // passa no filtro de 'recent' (diferença negativa)
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        expect(res.available).toBe(true);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toBe("Houve incidentes recentes");
+        // ✅ cobre formatter (Invalid Date -> undefined) no ramo 'recent' (linha ~71)
+        expect(res.lastIncidentAt).toBeUndefined();
+    });
+
+    it("sem ativos e 'recent' com lastchange=0 dentro de uma janela ENORME → incidents_recent=true e lastIncidentAt undefined (!seconds)", async () => {
+        vi.resetModules();
+        // Janela absurdamente grande para que 1970 (0) caiba como 'recente'
+        process.env.ZABBIX_DEFAULT_HOST = "Zabbix server";
+        process.env.ZABBIX_RECENT_WINDOW_MS = String(9e20); // muito > now
+
+        zabbixRpcMock.mockResolvedValueOnce([
+            { value: "0", lastchange: "0" }, // 01/01/1970
+        ]);
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        const res = await getSaudeDosServidoresFilas(
+            "PRD - RabbitMQ"
+        );
+
+        // cai no ramo hasRecent === true
+        expect(res.available).toBe(true);
+        expect(res.incidents_recent).toBe(true);
+        expect(res.message).toBe("Houve incidentes recentes");
+
+        // ...mas o formatter recebe seconds=0 → !seconds ⇒ undefined
+        expect(res.lastIncidentAt).toBeUndefined();
+    });
+
+    it("usa fallback 'Zabbix server' quando ZABBIX_DEFAULT_HOST está undefined (ramo do ??)", async () => {
+        // isola o módulo com a env ausente para recalcular DEFAULT_HOST
+        vi.resetModules();
+        delete process.env.ZABBIX_DEFAULT_HOST; // <- undefined
+        process.env.ZABBIX_RECENT_WINDOW_MS = String(24 * 60 * 60 * 1000); // mantém janela
+        zabbixRpcMock.mockResolvedValueOnce([]); // não importa o resultado, só validaremos os params
+
+        const { getSaudeDosServidoresFilas } = await import(
+            "@/actions/saude-dos-servidores"
+        );
+        await getSaudeDosServidoresFilas("PRD - RabbitMQ"); // sem 'host' para usar o default
+
+        const calledParams = zabbixRpcMock.mock.calls[0][1];
+        expect(calledParams.filter.description).toEqual("PRD - RabbitMQ");
+        expect(calledParams.filter.host).toBeUndefined(); // sem filtro de host
+    });
+});

--- a/src/actions/saude-dos-servidores.ts
+++ b/src/actions/saude-dos-servidores.ts
@@ -1,0 +1,78 @@
+import "server-only";
+import { zabbixRpc } from "@/lib/zabbix.server";
+import { formatDDMMYYYY_HHMM_FromSeconds } from "@/lib/utils";
+
+export type ProducaoStatus = {
+    available: boolean;
+    incidents_recent: boolean;
+    message: string;
+    /** Data e hora do último incidente (dd/mm/aaaa HH:mm) quando houver ativo ou recente */
+    lastIncidentAt?: string;
+};
+
+const DEFAULT_HOST = process.env.ZABBIX_DEFAULT_HOST ?? "Zabbix server";
+const RECENT_WINDOW_MS = Number(
+    process.env.ZABBIX_RECENT_WINDOW_MS ?? 24 * 60 * 60 * 1000
+);
+
+type Trigger = { lastchange: string; value: string };
+
+
+export async function getSaudeDosServidoresFilas(
+    projectName: string,
+    host = DEFAULT_HOST
+): Promise<ProducaoStatus> {
+    const params = {
+        host: host,
+        output: "extend" as const, // igual ao Postman
+        selectFunctions: "extend",
+        filter: { description: projectName },
+    };
+
+    const triggers = await zabbixRpc<Trigger[]>("trigger.get", params, 1);
+
+    // Sem triggers
+    if (!triggers?.length) {
+        return {
+            available: true,
+            incidents_recent: false,
+            message: "Sem incidentes recentes",
+        };
+    }
+
+    const now = Date.now();
+
+    // Incidentes ativos
+    const active = triggers.filter((t) => t.value === "1");
+    if (active.length > 0) {
+        const lastActiveSec = Math.max(
+            ...active.map((t) => Number(t.lastchange) || 0)
+        );
+        return {
+            available: false,
+            incidents_recent: true,
+            message: "Há incidentes ativos",
+            lastIncidentAt: formatDDMMYYYY_HHMM_FromSeconds(lastActiveSec),
+        };
+    }
+
+    // Houve incidentes recentes (janela configurável)
+    const recent = triggers.filter(
+        (t) => now - Number(t.lastchange) * 1000 <= RECENT_WINDOW_MS
+    );
+    const hasRecent = recent.length > 0;
+    const lastRecentSec = hasRecent
+        ? Math.max(...recent.map((t) => Number(t.lastchange) || 0))
+        : undefined;
+
+    return {
+        available: true,
+        incidents_recent: hasRecent,
+        message: hasRecent
+            ? "Houve incidentes recentes"
+            : "Sem incidentes recentes",
+        lastIncidentAt: hasRecent
+            ? formatDDMMYYYY_HHMM_FromSeconds(lastRecentSec)
+            : undefined,
+    };
+}

--- a/src/app/api/saude-dos-servidores/filas/route.ts
+++ b/src/app/api/saude-dos-servidores/filas/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth"; // seu NextAuth já exporta auth()
+import { getSaudeDosServidoresFilas } from "@/actions/saude-dos-servidores";
+
+export const runtime = "nodejs";      // garante Node runtime (axios)
+export const revalidate = 0;          // sem cache estático
+
+export async function GET(req: NextRequest) {
+  // 1) Protege com NextAuth
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  // 2) Lê parâmetros
+  const { searchParams } = new URL(req.url);
+  const project = searchParams.get("project") ?? "";
+  const host = searchParams.get("host") ?? undefined;
+  if (!project) return NextResponse.json({ error: "project é obrigatório" }, { status: 400 });
+
+  // 3) Chama a action (server-only)
+  try {
+    const status = await getSaudeDosServidoresFilas(project, host);
+
+    return NextResponse.json(status);
+  } catch (e: unknown) {
+    const errorMessage =
+      typeof e === "object" && e !== null && "message" in e
+        ? (e as { message?: string }).message
+        : "Erro ao consultar Zabbix";
+    return NextResponse.json({ error: errorMessage ?? "Erro ao consultar Zabbix" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -1,24 +1,32 @@
 // src/app/dashboard/page.test.tsx
+/* @vitest-environment jsdom */
 import { render, screen } from "@testing-library/react";
 import { vi, describe, test, beforeEach } from "vitest";
 import Dashboard from "./page";
 import { withClient } from "@/__mocks__/renderWithClient";
 
-// ✅ Mock do store para controlar o estado usado na página
-vi.mock("@/states/dashboard", () => {
-  return {
-    __esModule: true,
-    default: (selector: (state: { activeProject: { zabbixQueryFrontend: string; zabbixQueryBackend: string } }) => unknown) =>
-      selector({
-        activeProject: {
-          zabbixQueryFrontend: "Portal SME",
-          zabbixQueryBackend: "API SME",
-        },
-      }),
+// 🔧 Mock do store com estado configurável por teste
+type StoreState = {
+  activeProject: null | {
+    zabbixQueryFrontend?: string;
+    zabbixQueryBackend?: string;
+    zabbixQueryFilasRabbitMQ?: string;
   };
-});
+};
+let mockStoreState: StoreState = {
+  activeProject: {
+    zabbixQueryFrontend: "Portal SME",
+    zabbixQueryBackend: "API SME",
+    zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
+  },
+};
 
-// ✅ Mock dos filhos para simplificar a renderização e permitir asserts claros
+vi.mock("@/states/dashboard", () => ({
+  __esModule: true,
+  default: (selector: (s: StoreState) => unknown) => selector(mockStoreState),
+}));
+
+// 🔧 Mocks simples dos filhos
 vi.mock("@/components/dashboard/CardWrapperInfoAmbientes", () => ({
   __esModule: true,
   default: ({ title, children }: { title: string; children: React.ReactNode }) => (
@@ -33,20 +41,79 @@ vi.mock("@/components/dashboard/DisponibilidadeDosAmbientes/Producao", () => ({
   ),
 }));
 
+vi.mock("@/components/dashboard/SaudeDosServidores/Filas", () => ({
+  __esModule: true,
+  default: ({ title, projectName }: { title: string; projectName: string }) => (
+    <div data-testid={`filas-${title ?? "Filas"}`}>{projectName}</div>
+  ),
+}));
+
 describe("Dashboard page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockStoreState = {
+      activeProject: {
+        zabbixQueryFrontend: "Portal SME",
+        zabbixQueryBackend: "API SME",
+        zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
+      },
+    };
   });
 
   test("renderiza os cards e passa os nomes de projeto corretos", () => {
     render(withClient(<Dashboard />));
 
-    // Primeiro card (Frontend, sem title explícito no Producao)
+    // Primeiro card (Frontend)
     expect(screen.getByTestId("card-Disponibilidade do ambiente")).toBeInTheDocument();
     expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("Portal SME");
 
-    // Segundo card (Backend, com title="API Service" no Producao)
+    // Segundo card (Saúde do servidor)
     expect(screen.getByTestId("card-Saúde do servidor (Workloads)")).toBeInTheDocument();
     expect(screen.getByTestId("producao-API Service")).toHaveTextContent("API SME");
+
+    // Filas
+    expect(screen.getByTestId("filas-Fila")).toHaveTextContent("Filas RabbitMQ");
+  });
+
+  test("quando não há projeto ativo, passa strings vazias para os filhos (ramo do ??)", () => {
+    mockStoreState = { activeProject: null };
+
+    render(withClient(<Dashboard />));
+
+    expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("");
+    expect(screen.getByTestId("producao-API Service")).toHaveTextContent("");
+    expect(screen.getByTestId("filas-Fila")).toHaveTextContent("");
+  });
+
+  test("trima os nomes antes de passar (ramo do ?.trim())", () => {
+    mockStoreState = {
+      activeProject: {
+        zabbixQueryFrontend: "   Portal SME   ",
+        zabbixQueryBackend: "   API SME   ",
+        zabbixQueryFilasRabbitMQ: "   Filas RabbitMQ   ",
+      },
+    };
+
+    render(withClient(<Dashboard />));
+
+    expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("Portal SME");
+    expect(screen.getByTestId("producao-API Service")).toHaveTextContent("API SME");
+    expect(screen.getByTestId("filas-Fila")).toHaveTextContent("Filas RabbitMQ");
+  });
+
+  test("quando um campo específico está undefined, cai no fallback vazio para aquele filho", () => {
+    mockStoreState = {
+      activeProject: {
+        zabbixQueryFrontend: "Portal SME",
+        zabbixQueryBackend: "API SME",
+        // RabbitMQ ausente → deve virar ""
+      },
+    };
+
+    render(withClient(<Dashboard />));
+
+    expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("Portal SME");
+    expect(screen.getByTestId("producao-API Service")).toHaveTextContent("API SME");
+    expect(screen.getByTestId("filas-Fila")).toHaveTextContent(""); // fallback
   });
 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,23 +1,42 @@
 "use client";
-import  CardWrapperInfoAmbientes from "@/components/dashboard/CardWrapperInfoAmbientes";
+import CardWrapperInfoAmbientes from "@/components/dashboard/CardWrapperInfoAmbientes";
 import Producao from "@/components/dashboard/DisponibilidadeDosAmbientes/Producao";
+import Filas from "@/components/dashboard/SaudeDosServidores/Filas";
 import useDashboardStore from "@/states/dashboard";
 
 export default function Dashboard() {
-
     const activeProject = useDashboardStore((state) => state.activeProject);
     const projectNameFrontEnd = activeProject?.zabbixQueryFrontend?.trim();
     const projectNameBackEnd = activeProject?.zabbixQueryBackend?.trim();
+    const projectNameFilasRabbitMQ = activeProject?.zabbixQueryFilasRabbitMQ?.trim();
 
     return (
         <div className="border-b bg-background px-6 py-4">
             <div className="flex space-x-4 mb-6">
-                <CardWrapperInfoAmbientes title = "Disponibilidade do ambiente" className="max-w-sm mb-5">
-                    <Producao projectName={projectNameFrontEnd ?? ""} />
+                <CardWrapperInfoAmbientes
+                    title="Disponibilidade do ambiente"
+                    className="max-w-sm mb-5"
+                >
+                    <Producao
+                        className="bg-[#F5F5F5] p-3"
+                        projectName={projectNameFrontEnd ?? ""}
+                    />
                 </CardWrapperInfoAmbientes>
 
-                <CardWrapperInfoAmbientes title = "Saúde do servidor (Workloads)" className="max-w-sm mb-5">
-                    <Producao title="API Service" projectName={projectNameBackEnd ?? ""} />
+                <CardWrapperInfoAmbientes
+                    title="Saúde do servidor (Workloads)"
+                    className="max-w-sm mb-5"
+                >
+                    <Filas
+                        title="Fila"
+                        className="mb-5 bg-[#F5F5F5] p-3"
+                        projectName={projectNameFilasRabbitMQ ?? ""}
+                    />
+                    <Producao
+                        title="API Service"
+                        className="bg-[#F5F5F5] p-3"
+                        projectName={projectNameBackEnd ?? ""}
+                    />
                 </CardWrapperInfoAmbientes>
             </div>
         </div>

--- a/src/components/dashboard/CardWrapperInfoAmbientes/index.tsx
+++ b/src/components/dashboard/CardWrapperInfoAmbientes/index.tsx
@@ -22,7 +22,7 @@ export default function CardWrapperInfoAmbientes({
                 </CardTitle>
             </CardHeader>
             <CardContent className="px-4 pb-3">
-                <div className="rounded-md bg-[#F5F5F5] p-3">{children}</div>
+                <div className="rounded-md ">{children}</div>
             </CardContent>
         </Card>
     );

--- a/src/components/dashboard/SaudeDosServidores/Filas/index.test.tsx
+++ b/src/components/dashboard/SaudeDosServidores/Filas/index.test.tsx
@@ -1,0 +1,258 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import Filas from "./index";
+
+vi.mock("@/components/ui/skeleton", () => ({
+    __esModule: true,
+    Skeleton: ({ className }: { className?: string }) => (
+        <div data-testid="skeleton" className={className} />
+    ),
+}));
+vi.mock("@/components/ui/button", () => ({
+    __esModule: true,
+    Button: ({
+        children,
+        onClick,
+        className,
+    }: React.PropsWithChildren<{
+        onClick?: () => void;
+        className?: string;
+    }>) => (
+        <button data-testid="button" className={className} onClick={onClick}>
+            {children}
+        </button>
+    ),
+}));
+
+const mockHook = vi.fn();
+vi.mock("@/hooks/useSaudeDosServidores", () => ({
+    __esModule: true,
+    useFetchSaudeDosServidoresFilas: (...args: unknown[]) =>
+        mockHook(...args),
+}));
+
+describe("<Filas />", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        // ✅ Retorno padrão para evitar erro de destructuring quando projectName = ""
+        mockHook.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+    });
+
+    it("exibe mensagem para selecionar projeto quando projectName está vazio", () => {
+        // usa o retorno padrão acima
+        render(<Filas projectName="" />);
+        expect(screen.getByText("Produção")).toBeInTheDocument();
+        expect(screen.getByText("Selecione um projeto")).toBeInTheDocument();
+    });
+
+    it("exibe skeleton quando isLoading=true", () => {
+        mockHook.mockReturnValue({
+            data: undefined,
+            isLoading: true,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+        render(<Filas projectName="PRD - RabbitMQ" />);
+        expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(
+            2
+        );
+    });
+
+    it("exibe skeleton quando isFetching=true", () => {
+        mockHook.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: false,
+            isFetching: true,
+            refetch: vi.fn(),
+        });
+        render(<Filas projectName="PRD - RabbitMQ" />);
+        expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(
+            2
+        );
+    });
+
+    it("exibe erro quando isError=true e permite refetch", () => {
+        const refetch = vi.fn();
+        mockHook.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: true,
+            isFetching: false,
+            refetch,
+        });
+        render(<Filas projectName="PRD - RabbitMQ" />);
+        fireEvent.click(screen.getByTestId("button"));
+        expect(refetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("exibe erro quando !data (mesmo sem isError)", () => {
+        mockHook.mockReturnValue({
+            data: undefined,
+            isLoading: false,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+        render(<Filas projectName="PRD - RabbitMQ" />);
+        expect(
+            screen.getByText("Não foi possível carregar o status.")
+        ).toBeInTheDocument();
+    });
+
+    it("sucesso: incidents_recent=false → 'Sem incidentes recentes' + Disponível", () => {
+        mockHook.mockReturnValue({
+            data: {
+                available: true,
+                message: undefined,
+                incidents_recent: false,
+                lastIncidentAt: null,
+            },
+            isLoading: false,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+        render(<Filas projectName="PRD - RabbitMQ" />);
+        expect(screen.getByText("Sem incidentes recentes")).toBeInTheDocument();
+        expect(screen.getByLabelText("Status: Disponível")).toHaveTextContent(
+            "Disponível"
+        );
+    });
+
+    it("sucesso: incidents_recent=true → 'Houve incidentes recentes' + Indisponível", () => {
+        mockHook.mockReturnValue({
+            data: {
+                available: false,
+                message: undefined,
+                incidents_recent: true,
+                lastIncidentAt: null,
+            },
+            isLoading: false,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+        render(<Filas projectName="PRD - RabbitMQ" />);
+        expect(
+            screen.getByText("Houve incidentes recentes")
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText("Status: Indisponível")).toHaveTextContent(
+            "Indisponível"
+        );
+    });
+
+    it('sucesso: message === "Houve incidentes recentes" + lastIncidentAt', () => {
+        mockHook.mockReturnValue({
+            data: {
+                available: false,
+                message: "Houve incidentes recentes",
+                incidents_recent: true,
+                lastIncidentAt: "2025-09-03 10:00",
+            },
+            isLoading: false,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+        render(<Filas title="API Service" projectName="PRD - RabbitMQ" />);
+        expect(
+            screen.getByText("Houve incidentes recentes - 2025-09-03 10:00")
+        ).toBeInTheDocument();
+        expect(
+            screen.getByLabelText("Status: Indisponível")
+        ).toBeInTheDocument();
+    });
+
+    it('sucesso: message customizada (≠ "Houve incidentes recentes") → usa exatamente a mensagem', () => {
+        mockHook.mockReturnValue({
+            data: {
+                available: true,
+                message: "Sistema em manutenção programada",
+                incidents_recent: true, // irrelevante porque message está definido
+                lastIncidentAt: "2025-09-03 10:00", // não deve ser concatenado
+            },
+            isLoading: false,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+
+        render(<Filas projectName="PRD - RabbitMQ" />);
+        // deve exibir exatamente a message, sem sufixo de data
+        expect(
+            screen.getByText("Sistema em manutenção programada")
+        ).toBeInTheDocument();
+
+        // pílula continua funcionando normalmente
+        expect(screen.getByLabelText("Status: Disponível")).toBeInTheDocument();
+    });
+
+    it('sucesso: message === "Houve incidentes recentes" mas sem lastIncidentAt → NÃO concatena', () => {
+        mockHook.mockReturnValue({
+            data: {
+                available: true,
+                message: "Houve incidentes recentes",
+                incidents_recent: true, // irrelevante pq message está definido
+                lastIncidentAt: null, // 👈 força o branch true && false
+            },
+            isLoading: false,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+
+        render(<Filas projectName="PRD - RabbitMQ" />);
+
+        // Deve exibir exatamente "Houve incidentes recentes" (sem " - data")
+        expect(
+            screen.getByText("Houve incidentes recentes")
+        ).toBeInTheDocument();
+        // E não deve existir a versão concatenada
+        expect(
+            screen.queryByText(/Houve incidentes recentes\s*-\s*/i)
+        ).not.toBeInTheDocument();
+
+        // Pílula segue normal
+        expect(screen.getByLabelText("Status: Disponível")).toBeInTheDocument();
+    });
+
+    it("usa fallback do ?? e chama o hook com string vazia quando projectName é undefined", () => {
+        // retorno padrão já vem do beforeEach
+        render(<Filas projectName={undefined as unknown as string} />);
+
+        // Continua mostrando o estado 'selecione um projeto'
+        expect(screen.getByText("Produção")).toBeInTheDocument();
+        expect(screen.getByText("Selecione um projeto")).toBeInTheDocument();
+
+        // ✅ garante que o branch do ?? foi exercitado (arg = "")
+        expect(mockHook).toHaveBeenCalledWith("");
+    });
+
+    it("sucesso: message === null cai no else do && e usa incidents_recent (false → 'Sem incidentes recentes')", () => {
+        mockHook.mockReturnValue({
+            data: {
+                available: true,
+                message: null, // 👈 cobre o ramo (message !== undefined) true e (message !== null) false
+                incidents_recent: false, // cai no fallback "Sem incidentes recentes"
+                lastIncidentAt: "2025-09-03 10:00", // ignorado nesse ramo
+            },
+            isLoading: false,
+            isError: false,
+            isFetching: false,
+            refetch: vi.fn(),
+        });
+
+        render(<Filas projectName="PRD - RabbitMQ" />);
+        expect(screen.getByText("Sem incidentes recentes")).toBeInTheDocument();
+        expect(screen.getByLabelText("Status: Disponível")).toBeInTheDocument();
+    });
+});

--- a/src/components/dashboard/SaudeDosServidores/Filas/index.tsx
+++ b/src/components/dashboard/SaudeDosServidores/Filas/index.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Check, XCircle, RotateCcw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useFetchSaudeDosServidoresFilas } from "@/hooks/useSaudeDosServidores";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+
+type ProducaoProps = {
+    readonly projectName: string; // não está sendo usado, pois pegamos da store
+    readonly title?: string; // default "Produção"
+    readonly className?: string;
+};
+
+export default function Filas({
+    title = "Produção",
+    className,
+    projectName,
+}: ProducaoProps) {
+
+    const { data, isLoading, isError, refetch, isFetching } =
+        useFetchSaudeDosServidoresFilas(projectName ?? "");
+
+    if (!projectName) {
+        return (
+            <div className={cn("text-center", className)}>
+                <div className="font-semibold text-xl">{title}</div>
+                <div className="text-sm text-muted-foreground">
+                    Selecione um projeto
+                </div>
+            </div>
+        );
+    }
+
+    if (isLoading || isFetching) {
+        return (
+            <div className={cn("text-center", className)}>
+                <div className="font-semibold text-xl">{title}</div>
+                <div className="mt-1 text-sm text-muted-foreground">
+                    <Skeleton className="mx-auto h-4 w-44" />
+                </div>
+                <Skeleton className="mx-auto mt-3 h-6 w-full rounded-full" />
+            </div>
+        );
+    }
+
+    if (isError || !data) {
+        return (
+            <div className={cn("text-center", className)}>
+                <div className="font-semibold text-xl">{title}</div>
+                <div className="text-sm text-muted-foreground">
+                    Não foi possível carregar o status.
+                </div>
+                <Button
+                    onClick={() => refetch()}
+                    variant="secondary"
+                    size="sm"
+                    className="mt-3"
+                >
+                    <RotateCcw className="mr-2 h-4 w-4" />
+                    Tentar novamente
+                </Button>
+            </div>
+        );
+    }
+
+    const available = data.available;
+    let subtitleMessage: string;
+    if (data.message !== undefined && data.message !== null) {
+        subtitleMessage = data.message;
+    } else {
+        subtitleMessage = data.incidents_recent
+            ? "Houve incidentes recentes"
+            : "Sem incidentes recentes";
+    }
+
+    const subtitle =
+        data.message === "Houve incidentes recentes" && data.lastIncidentAt
+            ? `Houve incidentes recentes - ${data.lastIncidentAt}`
+            : subtitleMessage;
+
+    return (
+        <div className={cn("text-center", className)}>
+            <div className="font-semibold text-xl">{title}</div>
+            <div className="text-sm text-muted-foreground">{subtitle}</div>
+
+            {/* pílula */}
+            <div
+                className={cn(
+                    "mt-3 h-6 w-full rounded-full px-2",
+                    "flex items-center justify-center gap-2 text-xs font-medium",
+                    available
+                        ? "bg-emerald-500 text-white"
+                        : "bg-red-500 text-white"
+                )}
+                aria-label={`Status: ${
+                    available ? "Disponível" : "Indisponível"
+                }`}
+            >
+                {available ? (
+                    <Check className="h-5 w-5" aria-hidden="true" />
+                ) : (
+                    <XCircle className="h-5 w-5" aria-hidden="true" />
+                )}
+                {available ? "Disponível" : "Indisponível"}
+            </div>
+        </div>
+    );
+}

--- a/src/components/dashboard/SelectSistemas/getSistemasPorSquad.ts
+++ b/src/components/dashboard/SelectSistemas/getSistemasPorSquad.ts
@@ -3,32 +3,32 @@ import { Sistema } from "./schema"; // Importando o tipo do schema
 // Hashtable (Record é uma forma de definir chave/valor no TS)
 const squads: Record<string, Sistema[]> = {
     ASCOM: [
-        { id: "1", nome: "Portal Educação", zabbixQueryFrontend: "PRD - Educacao", zabbixQueryBackend: "" },
-        { id: "2", nome: "Portal CEU", zabbixQueryFrontend: "PRD - Portal CEU", zabbixQueryBackend: "" },
-        { id: "3", nome: "Plateia", zabbixQueryFrontend: "PRD - Plateia", zabbixQueryBackend: "PRD - Plateia - API" },
-        { id: "4", nome: "Plateia App", zabbixQueryFrontend: "", zabbixQueryBackend: "" },
-        { id: "5", nome: "Intranet", zabbixQueryFrontend: "PRD - Intranet", zabbixQueryBackend: "" },
+        { id: "1", nome: "Portal Educação", zabbixQueryFrontend: "PRD - Educacao", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" },
+        { id: "2", nome: "Portal CEU", zabbixQueryFrontend: "PRD - Portal CEU", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" },
+        { id: "3", nome: "Plateia", zabbixQueryFrontend: "PRD - Plateia", zabbixQueryBackend: "PRD - Plateia - API", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" },
+        { id: "4", nome: "Plateia App", zabbixQueryFrontend: "", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" },
+        { id: "5", nome: "Intranet", zabbixQueryFrontend: "PRD - Intranet", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" },
     ],
     COGEP: [
-        { id: "6", nome: "Escolhas", zabbixQueryFrontend: "PRD - Escolhas", zabbixQueryBackend: "" },
-        { id: "7", nome: "Sigla", zabbixQueryFrontend: "", zabbixQueryBackend: "" },
+        { id: "6", nome: "Escolhas", zabbixQueryFrontend: "PRD - Escolhas", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" },
+        { id: "7", nome: "Sigla", zabbixQueryFrontend: "", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" },
     ],
     CODAE: [
-        { id: "8", nome: "SigPAE", zabbixQueryFrontend: "PRD - SIGPAE", zabbixQueryBackend: "PRD - SIGPAE - API" },
-        { id: "9", nome: "Rolê Agroecológico", zabbixQueryFrontend: "", zabbixQueryBackend: "" },
+        { id: "8", nome: "SigPAE", zabbixQueryFrontend: "PRD - SIGPAE", zabbixQueryBackend: "PRD - SIGPAE - API", zabbixQueryFilasRabbitMQ: "" },
+        { id: "9", nome: "Rolê Agroecológico", zabbixQueryFrontend: "", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" },
     ],
     COPED: [
-        { id: "10", nome: "Novo SGP", zabbixQueryFrontend: "PRD - Novo SGP", zabbixQueryBackend: "PRD - Novo SGP - Swagger" },
-        { id: "11", nome: "Serap", zabbixQueryFrontend: "PRD - Serap", zabbixQueryBackend: "" },
-        { id: "12", nome: "Serap Estudantes", zabbixQueryFrontend: "PRD - Serap Estudantes", zabbixQueryBackend: "PRD - Serap Estudantes - API" },
-        { id: "13", nome: "Cdep", zabbixQueryFrontend: "PRD - CDEP", zabbixQueryBackend: "PRD - CDEP - API" },
-        { id: "14", nome: "Curriculo da Cidade", zabbixQueryFrontend: "PRD - Curriculo", zabbixQueryBackend: "PRD - Curriculo - API" },
-        { id: "15", nome: "IDEP", zabbixQueryFrontend: "PRD - Idep", zabbixQueryBackend: "" },
-        { id: "16", nome: "Conecta Formação", zabbixQueryFrontend: "PRD - Conecta Formacao", zabbixQueryBackend: "PRD - Conecta Formacao - API" },
+        { id: "10", nome: "Novo SGP", zabbixQueryFrontend: "PRD - Novo SGP", zabbixQueryBackend: "PRD - Novo SGP - Swagger", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" },
+        { id: "11", nome: "Serap", zabbixQueryFrontend: "PRD - Serap", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" },
+        { id: "12", nome: "Serap Estudantes", zabbixQueryFrontend: "PRD - Serap Estudantes", zabbixQueryBackend: "PRD - Serap Estudantes - API", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" },
+        { id: "13", nome: "Cdep", zabbixQueryFrontend: "PRD - CDEP", zabbixQueryBackend: "PRD - CDEP - API", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" },
+        { id: "14", nome: "Curriculo da Cidade", zabbixQueryFrontend: "PRD - Curriculo", zabbixQueryBackend: "PRD - Curriculo - API", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" },
+        { id: "15", nome: "IDEP", zabbixQueryFrontend: "PRD - Idep", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" },
+        { id: "16", nome: "Conecta Formação", zabbixQueryFrontend: "PRD - Conecta Formacao", zabbixQueryBackend: "PRD - Conecta Formacao - API", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" },
     ],
-    COPLAN: [{ id: "17", nome: "SigEscola", zabbixQueryFrontend: "PRD - PTRF - SIG Escola", zabbixQueryBackend: "PRD - PTRF - SIG Escola - API" }],
-    COTIC: [{ id: "18", nome: "Autosserviço", zabbixQueryFrontend: "PRD - AUTOSSERVICO", zabbixQueryBackend: "" }],
-    GIPE: [{ id: "19", nome: "GIPE", zabbixQueryFrontend: "", zabbixQueryBackend: "" }],
+    COPLAN: [{ id: "17", nome: "SigEscola", zabbixQueryFrontend: "PRD - PTRF - SIG Escola", zabbixQueryBackend: "PRD - PTRF - SIG Escola - API", zabbixQueryFilasRabbitMQ: "" }],
+    COTIC: [{ id: "18", nome: "Autosserviço", zabbixQueryFrontend: "PRD - AUTOSSERVICO", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" }],
+    GIPE: [{ id: "19", nome: "GIPE", zabbixQueryFrontend: "", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "" }],
 };
 
 export function getSistemasPorSquad(squadName: string): Sistema[] {

--- a/src/components/dashboard/SelectSistemas/index.tsx
+++ b/src/components/dashboard/SelectSistemas/index.tsx
@@ -36,6 +36,7 @@ export function SelectSistemas() {
                     ...selectedSistema,
                     zabbixQueryFrontend: selectedSistema.zabbixQueryFrontend,
                     zabbixQueryBackend: selectedSistema.zabbixQueryBackend,
+                    zabbixQueryFilasRabbitMQ: selectedSistema.zabbixQueryFilasRabbitMQ,
                 });
             }
         },

--- a/src/components/dashboard/SelectSistemas/schema.test.ts
+++ b/src/components/dashboard/SelectSistemas/schema.test.ts
@@ -3,7 +3,7 @@ import { SistemaSchema, SelectedSistemaSchema } from "./schema";
 
 describe("SistemaSchema", () => {
     it("deve validar um objeto Sistema válido", () => {
-        const validSistema = { id: "10", nome: "Novo SGP", zabbixQueryFrontend: "PRD - Novo SGP", zabbixQueryBackend: "PRD - Novo SGP - API" };
+        const validSistema = { id: "10", nome: "Novo SGP", zabbixQueryFrontend: "PRD - Novo SGP", zabbixQueryBackend: "PRD - Novo SGP - API", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ" };
         const result = SistemaSchema.safeParse(validSistema);
 
         expect(result.success).toBe(true);

--- a/src/components/dashboard/SelectSistemas/schema.ts
+++ b/src/components/dashboard/SelectSistemas/schema.ts
@@ -6,6 +6,7 @@ export const SistemaSchema = z.object({
   nome: z.string(),
   zabbixQueryFrontend: z.string(),
   zabbixQueryBackend: z.string(),
+  zabbixQueryFilasRabbitMQ: z.string(),
 });
 
 export type Sistema = z.infer<typeof SistemaSchema>;

--- a/src/hooks/useSaudeDosServidores.test.tsx
+++ b/src/hooks/useSaudeDosServidores.test.tsx
@@ -1,0 +1,74 @@
+/* @vitest-environment jsdom */
+import React from "react";
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ProducaoStatus } from "@/actions/saude-dos-servidores";
+import { useFetchSaudeDosServidoresFilas } from "./useSaudeDosServidores";
+
+describe("useFetchSaudeDosServidoresFilas", () => {
+  let queryClient: QueryClient;
+
+    beforeEach(() => {
+    // ✅ QueryClient “de teste”: sem retries (evita ficar pendurado em erro)
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: 0, // não precisa, mas ajuda a não acumular cache entre execuções
+        },
+      },
+    });
+
+    vi.restoreAllMocks();
+    globalThis.fetch = vi.fn();
+  });
+
+  const wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  it("não chama fetch quando projectName vazio (enabled=false)", async () => {
+    const r = renderHook(
+      () => useFetchSaudeDosServidoresFilas(""),
+      { wrapper }
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+    // estado inicial sem erro
+    expect(r.result.current.isError).toBeFalsy();
+  });
+
+  it("retorna dados de sucesso", async () => {
+    const data: ProducaoStatus = {
+      available: true,
+      incidents_recent: false,
+      message: "Sem incidentes recentes",
+    };
+    (global.fetch as Mock).mockResolvedValue(
+      new Response(JSON.stringify(data), { status: 200 })
+    );
+
+    const { result } = renderHook(
+      () => useFetchSaudeDosServidoresFilas("PRD - RabbitMQ", "Zabbix server"),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(data);
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/saude-dos-servidores/filas?"),
+      { cache: "no-store" }
+    );
+  });
+
+  it("propaga erro quando response !ok", async () => {
+    (global.fetch as Mock).mockResolvedValue(new Response("ERR", { status: 500 }));
+
+    const { result } = renderHook(
+      () => useFetchSaudeDosServidoresFilas("PRD - RabbitMQ"),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/src/hooks/useSaudeDosServidores.ts
+++ b/src/hooks/useSaudeDosServidores.ts
@@ -1,0 +1,16 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ProducaoStatus } from "@/actions/saude-dos-servidores";
+
+export function useFetchSaudeDosServidoresFilas(projectName: string, host?: string) {
+  return useQuery<ProducaoStatus>({
+    queryKey: ["get-saude-dos-servidores-filas", projectName, host],
+    enabled: !!projectName,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      const qs = new URLSearchParams({ project: projectName, ...(host ? { host } : {}) });
+      const res = await fetch(`/api/saude-dos-servidores/filas?${qs.toString()}`, { cache: "no-store" });
+      if (!res.ok) throw new Error("Falha ao buscar status");
+      return res.json();
+    },
+  });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -13,3 +13,15 @@ export function numberToBRL(n: number): string {
 
   return n < 0 ? `R$ -${absValue.replace("R$", "").trim()}` : absValue;
 }
+
+export function formatDDMMYYYY_HHMM_FromSeconds(seconds?: number): string | undefined {
+    if (!seconds || !isFinite(seconds)) return undefined;
+    const d = new Date(seconds * 1000);
+    if (isNaN(d.getTime())) return undefined;
+    const dd = String(d.getDate()).padStart(2, "0");
+    const mm = String(d.getMonth() + 1).padStart(2, "0");
+    const yyyy = d.getFullYear();
+    const hh = String(d.getHours()).padStart(2, "0");
+    const mi = String(d.getMinutes()).padStart(2, "0");
+    return `${dd}/${mm}/${yyyy} ${hh}:${mi}`;
+}

--- a/src/states/dashboard.ts
+++ b/src/states/dashboard.ts
@@ -13,6 +13,7 @@ export interface ProjectItem {
     nome: string;
     zabbixQueryFrontend: string;
     zabbixQueryBackend: string;
+    zabbixQueryFilasRabbitMQ: string;
 }
 
 type State = {


### PR DESCRIPTION
Esse PR:

- Adiciona estados globais para zabbixQueryFilasRabbitMQ
- Melhora código separando função formatDDMMYYYY_HHMM_FromSeconds para utils
- Adiciona e altera testes para Componente Saúde dos Servidores - Filas do RabbitMQ
- Cria rota da API para consulta as Filas do RabbitMQ no Zabbix
- Implementa Componente Saúde dos Servidores - Filas do RabbitMQ

História: [AB#129586](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/129586) e Tarefa: [AB#133816](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/133816)