### PR TITLE
fix(lint): remove prop azureDevopsProjectName não utilizada

### DIFF
--- a/src/components/dashboard/AzureDevOpsBacklog/index.tsx
+++ b/src/components/dashboard/AzureDevOpsBacklog/index.tsx
@@ -9,7 +9,6 @@ import { getProjectIdentifiers, matchesBugToProject } from "./bugFilters";
 
 type Props = {
     readonly project?: string;
-    readonly azureDevopsProjectName?: string;
     readonly className?: string;
 };
 


### PR DESCRIPTION
## Resumo
- Remove prop `azureDevopsProjectName` não utilizada do tipo Props em AzureDevOpsBacklog