### PR TITLE
fix(lint): remove prop azureDevopsProjectName não utilizada

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,7 +13,6 @@ export default function Dashboard() {
     const projectNameFilasRabbitMQ = activeProject?.zabbixQueryFilasRabbitMQ?.trim();
     const projectName = activeProject?.nome?.trim();
     const jenkinsSubprojects = activeProject?.jenkinsSubprojects ?? [];
-    const azureDevopsProjectName = activeProject?.azureDevopsProjectName?.trim();
 
     return (
         <div className="border-b bg-background px-6 py-4">
@@ -61,7 +60,6 @@ export default function Dashboard() {
                     <AzureDevOpsBacklog
                         className="p-[2px]"
                         project={projectName ?? ""}
-                        azureDevopsProjectName={azureDevopsProjectName}
                     />
                 </CardWrapperInfoAmbientes>
             </div>

--- a/src/components/dashboard/AzureDevOpsBacklog/index.tsx
+++ b/src/components/dashboard/AzureDevOpsBacklog/index.tsx
@@ -9,7 +9,6 @@ import { getProjectIdentifiers, matchesBugToProject } from "./bugFilters";
 
 type Props = {
     readonly project?: string;
-    readonly azureDevopsProjectName?: string;
     readonly className?: string;
 };
 


### PR DESCRIPTION
## Resumo
- Remove prop `azureDevopsProjectName` não utilizada do tipo Props em AzureDevOpsBacklog