### PR TITLE
feat: Correção do filtro de bugs do dashboard e filtro por sprint

### DIFF
--- a/src/components/dashboard/AzureDevOpsBacklog/bugFilters.test.ts
+++ b/src/components/dashboard/AzureDevOpsBacklog/bugFilters.test.ts
@@ -148,10 +148,10 @@ describe("bugFilters", () => {
             ...overrides,
         });
 
-        it("retorna false para bug sem tags e sem identificador no título", () => {
+        it("retorna true para bug sem tags e sem identificador no título (aparece em todos os projetos)", () => {
             const bug = createBug({ title: "Bug genérico sem identificador", tags: undefined });
             const identifiers = getProjectIdentifiers("Novo SGP");
-            expect(matchesBugToProject(bug, identifiers)).toBe(false);
+            expect(matchesBugToProject(bug, identifiers)).toBe(true);
         });
 
         it("faz match por tag", () => {

--- a/src/components/dashboard/AzureDevOpsBacklog/bugFilters.ts
+++ b/src/components/dashboard/AzureDevOpsBacklog/bugFilters.ts
@@ -122,20 +122,59 @@ export function identifiersMatch(id1: string, id2: string): boolean {
 }
 
 /**
- * Verifica se um bug pertence a um projeto baseado no título e tags
+ * Retorna todos os identificadores conhecidos de todos os projetos.
+ */
+function getAllKnownIdentifiers(): string[] {
+    const allIdentifiers: string[] = [];
+    for (const identifiers of Object.values(PROJECT_IDENTIFIERS)) {
+        allIdentifiers.push(...identifiers);
+    }
+    return allIdentifiers;
+}
+
+/**
+ * Verifica se o texto contém algum identificador de projeto conhecido.
+ */
+function containsAnyKnownIdentifier(searchText: string): boolean {
+    const allIdentifiers = getAllKnownIdentifiers();
+    const cleanSearchText = searchText.replace(/[-\s]/g, "");
+
+    return allIdentifiers.some((id) => {
+        if (searchText.includes(id)) return true;
+        const cleanId = id.replace(/[-\s]/g, "");
+        if (cleanSearchText.includes(cleanId)) return true;
+        return false;
+    });
+}
+
+/**
+ * Verifica se um bug pertence a um projeto baseado no título e tags.
+ * Busca os identificadores do projeto em qualquer lugar do título ou das tags.
+ * Bugs sem identificadores conhecidos aparecem em todos os projetos.
  */
 export function matchesBugToProject(bug: WorkItem, projectIdentifiers: string[]): boolean {
-    const bugTags = parseTags(bug.tags);
-    const titleIdentifiers = extractTitleIdentifiers(bug.title);
+    const normalizedTitle = normalizeText(bug.title || "");
+    const normalizedTags = normalizeText(bug.tags || "");
 
-    // Combina tags e identificadores do título
-    const allBugIdentifiers = [...bugTags, ...titleIdentifiers];
+    // Combina título e tags para busca
+    const searchText = `${normalizedTitle} ${normalizedTags}`;
 
-    // Se o bug não tem nenhum identificador, não faz match
-    if (allBugIdentifiers.length === 0) return false;
+    // Bugs sem título e sem tags aparecem em todos os projetos
+    if (searchText.trim().length === 0) return true;
 
-    // Verifica se algum identificador do projeto faz match com algum identificador do bug
-    return projectIdentifiers.some((projectId) =>
-        allBugIdentifiers.some((bugId) => identifiersMatch(projectId, bugId))
-    );
+    // Se o bug não contém nenhum identificador conhecido, aparece em todos os projetos
+    if (!containsAnyKnownIdentifier(searchText)) return true;
+
+    // Verifica se algum identificador do projeto aparece no título ou nas tags
+    const cleanSearchText = searchText.replace(/[-\s]/g, "");
+    return projectIdentifiers.some((projectId) => {
+        // Busca exata do identificador
+        if (searchText.includes(projectId)) return true;
+
+        // Busca sem hífens e espaços
+        const cleanProjectId = projectId.replace(/[-\s]/g, "");
+        if (cleanSearchText.includes(cleanProjectId)) return true;
+
+        return false;
+    });
 }

--- a/src/components/dashboard/AzureDevOpsBacklog/bugFilters.ts
+++ b/src/components/dashboard/AzureDevOpsBacklog/bugFilters.ts
@@ -153,8 +153,8 @@ function containsAnyKnownIdentifier(searchText: string): boolean {
  * Bugs sem identificadores conhecidos aparecem em todos os projetos.
  */
 export function matchesBugToProject(bug: WorkItem, projectIdentifiers: string[]): boolean {
-    const normalizedTitle = normalizeText(bug.title || "");
-    const normalizedTags = normalizeText(bug.tags || "");
+    const normalizedTitle = normalizeText(bug.title ?? "");
+    const normalizedTags = normalizeText(bug.tags ?? "");
 
     // Combina título e tags para busca
     const searchText = `${normalizedTitle} ${normalizedTags}`;

--- a/src/components/dashboard/AzureDevOpsBacklog/index.tsx
+++ b/src/components/dashboard/AzureDevOpsBacklog/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import BacklogCard from "@/components/dashboard/BacklogCard";
 import { useAzureDevOpsBacklog } from "@/hooks/useAzureDevOpsBacklog";
 import { cn } from "@/lib/utils";
@@ -12,7 +12,50 @@ type Props = {
     readonly className?: string;
 };
 
+/**
+ * Extrai o nome da sprint do iteration_path.
+ * Ex: "SME - Sustentação\\Sprint 10" -> "Sprint 10"
+ */
+function getSprintName(iterationPath?: string): string {
+    if (!iterationPath) return "Sem Sprint";
+    const parts = iterationPath.split("\\");
+    return parts[parts.length - 1] || "Sem Sprint";
+}
+
+type SprintInfo = {
+    name: string;
+    count: number;
+};
+
+/**
+ * Extrai sprints únicas dos itens com contagem, ordenadas.
+ */
+function extractSprintsWithCount(items: WorkItem[]): SprintInfo[] {
+    const sprintCounts = new Map<string, number>();
+    for (const item of items) {
+        const sprintName = getSprintName(item.iteration_path);
+        sprintCounts.set(sprintName, (sprintCounts.get(sprintName) ?? 0) + 1);
+    }
+
+    const sprints: SprintInfo[] = Array.from(sprintCounts.entries()).map(([name, count]) => ({
+        name,
+        count,
+    }));
+
+    // Ordena sprints (tenta ordenar numericamente se possível)
+    sprints.sort((a, b) => {
+        const numA = parseInt(a.name.replace(/\D/g, ""), 10);
+        const numB = parseInt(b.name.replace(/\D/g, ""), 10);
+        if (!isNaN(numA) && !isNaN(numB)) return numB - numA; // Mais recente primeiro
+        return a.name.localeCompare(b.name);
+    });
+
+    return sprints;
+}
+
 export default function AzureDevOpsBacklog({ project, className }: Props) {
+    const [selectedSprint, setSelectedSprint] = useState<string | null>(null);
+
     const query = useAzureDevOpsBacklog({
         endpoint: "/api/azure-devops/backlog",
         keyPrefix: "azure-devops-backlog",
@@ -22,23 +65,48 @@ export default function AzureDevOpsBacklog({ project, className }: Props) {
         },
     });
 
-    const filteredQuery = useMemo(() => {
-        if (!query.data || !project) return query;
+    // Primeiro filtra por projeto, depois extrai sprints e aplica filtro de sprint
+    const { filteredQuery, sprintsWithCount, activeSprint, totalItems } = useMemo(() => {
+        if (!query.data || !project) {
+            return { filteredQuery: query, sprintsWithCount: [], activeSprint: "all", totalItems: 0 };
+        }
 
         const projectIdentifiers = getProjectIdentifiers(project);
 
-        const filterItems = (items: WorkItem[]) =>
+        // Filtra por projeto
+        const filterByProject = (items: WorkItem[]) =>
             items.filter((item) => matchesBugToProject(item, projectIdentifiers));
 
-        return {
-            ...query,
-            data: {
-                ...query.data,
-                parents: filterItems(query.data.parents),
-                children: filterItems(query.data.children),
-            },
+        const projectFilteredParents = filterByProject(query.data.parents);
+        const projectFilteredChildren = filterByProject(query.data.children);
+        const allProjectItems = [...projectFilteredParents, ...projectFilteredChildren];
+
+        // Extrai sprints disponíveis com contagem
+        const sprints = extractSprintsWithCount(allProjectItems);
+
+        // Define sprint padrão como a mais recente (primeira da lista ordenada)
+        const currentSprint = selectedSprint ?? sprints[0]?.name ?? "all";
+
+        // Filtra por sprint se selecionada
+        const filterBySprint = (items: WorkItem[]) => {
+            if (currentSprint === "all") return items;
+            return items.filter((item) => getSprintName(item.iteration_path) === currentSprint);
         };
-    }, [query, project]);
+
+        return {
+            filteredQuery: {
+                ...query,
+                data: {
+                    ...query.data,
+                    parents: filterBySprint(projectFilteredParents),
+                    children: filterBySprint(projectFilteredChildren),
+                },
+            },
+            sprintsWithCount: sprints,
+            activeSprint: currentSprint,
+            totalItems: allProjectItems.length,
+        };
+    }, [query, project, selectedSprint]);
 
     if (!project) {
         return (
@@ -52,12 +120,35 @@ export default function AzureDevOpsBacklog({ project, className }: Props) {
     }
 
     return (
-        <BacklogCard
-            title=""
-            className={className}
-            projectName="SME - Sustentação"
-            query={filteredQuery}
-            emptyProjectHint="Selecione um projeto"
-        />
+        <div className={className}>
+            {/* Filtro de Sprint */}
+            {sprintsWithCount.length > 0 && (
+                <div className="mb-4 flex items-center gap-2">
+                    <label htmlFor="sprint-filter" className="text-sm font-medium text-gray-700">
+                        Sprint:
+                    </label>
+                    <select
+                        id="sprint-filter"
+                        value={activeSprint}
+                        onChange={(e) => setSelectedSprint(e.target.value)}
+                        className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                    >
+                        <option value="all">Todas as Sprints ({totalItems})</option>
+                        {sprintsWithCount.map((sprint) => (
+                            <option key={sprint.name} value={sprint.name}>
+                                {sprint.name} ({sprint.count})
+                            </option>
+                        ))}
+                    </select>
+                </div>
+            )}
+
+            <BacklogCard
+                title=""
+                projectName="SME - Sustentação"
+                query={filteredQuery}
+                emptyProjectHint="Selecione um projeto"
+            />
+        </div>
     );
 }


### PR DESCRIPTION
## Resumo

Corrige problemas no filtro de bugs do dashboard Azure DevOps e adiciona funcionalidade de filtro por sprint.

## Alterações

### Correções no filtro de bugs
- Remove filtro de data padrão (mês atual) para buscar todos os bugs
- Corrige lógica de matching de bugs por projeto (busca identificadores em qualquer lugar do título/tags)
- Bugs sem identificadores agora aparecem em todos os projetos selecionados
- Remove tipo "Bug" genérico (não existe no Azure DevOps, apenas BugFix e HotFix)

### Nova funcionalidade: Filtro por Sprint
- Adiciona dropdown para filtrar bugs por sprint
- Mostra contagem de itens por sprint no dropdown
- Sprint mais recente é selecionada por padrão
- Opção "Todas as Sprints" mostra total de bugs do projeto

## Arquivos modificados
- `src/components/dashboard/AzureDevOpsBacklog/index.tsx` - Adiciona filtro de sprint
- `src/components/dashboard/AzureDevOpsBacklog/bugFilters.ts` - Corrige lógica de matching
- `src/components/dashboard/AzureDevOpsBacklog/bugFilters.test.ts` - Atualiza testes

## Teste
- [x] Testes unitários passando (366 testes)
- [ ] Testar filtro de bugs com diferentes projetos
- [ ] Testar filtro de sprint