### PR TITLE
feat: adiciona tooltips informativos nas seções da dashboard

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -29,6 +29,17 @@ export default function Dashboard() {
                     id="onboarding-disponibilidade"
                     title="Disponibilidade do ambiente"
                     className="max-w-sm"
+                    tooltipContent={
+                        <>
+                            <p className="mb-4">
+                                Essa seção monitora se o sistema está funcionando e acessível aos usuários.
+                                Disponibilidade significa que o sistema está no ar e pronto para uso, sem interrupções.
+                            </p>
+                            <p>
+                                Os ambientes podem estar Disponível, Indisponível ou em Alerta.
+                            </p>
+                        </>
+                    }
                 >
                     <Producao
                         className="bg-[#F5F5F5] p-3"
@@ -40,6 +51,17 @@ export default function Dashboard() {
                     id="onboarding-saude-servidor"
                     title="Saúde do servidor (Workloads)"
                     className="max-w-sm"
+                    tooltipContent={
+                        <>
+                            <p className="mb-4">
+                                A saúde de servidores e workloads apontam o estado de funcionamento, desempenho e
+                                estabilidade dos recursos computacionais que suportam aplicações e serviços de um sistema.
+                            </p>
+                            <p>
+                                O objetivo é garantir que os sistemas estejam disponíveis, performando bem e livres de falhas críticas.
+                            </p>
+                        </>
+                    }
                 >
                     <Filas
                         title="Fila"
@@ -59,6 +81,13 @@ export default function Dashboard() {
                     id="onboarding-bugs"
                     title="Bugs"
                     className="col-span-4 gap-2 py-2"
+                    tooltipContent={
+                        <p>
+                            Ao final da página será possível visualizar o registro dos bugs e
+                            correções necessárias para o sistema, suas tratativas e andamento para
+                            resolução.
+                        </p>
+                    }
                 >
                     <AzureDevOpsBacklog
                         className="p-[2px]"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Montserrat} from "next/font/google"
 import ReactQueryProvider from "@/lib/ReactQueryProvider";
+import { TooltipProvider } from "@/components/ui/tooltip";
 
 import "@/styles/globals.scss";
 
@@ -23,7 +24,11 @@ export default function RootLayout({
     return (
         <html lang="pt-br">
             <body className={`${montserrat.className} mx-auto`}>
-                <ReactQueryProvider>{children}</ReactQueryProvider>
+                <ReactQueryProvider>
+                    <TooltipProvider delayDuration={200}>
+                        {children}
+                    </TooltipProvider>
+                </ReactQueryProvider>
             </body>
         </html>
     );

--- a/src/components/dashboard/CardWrapperInfoAmbientes/index.tsx
+++ b/src/components/dashboard/CardWrapperInfoAmbientes/index.tsx
@@ -1,12 +1,19 @@
 "use client";
 
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+    Tooltip,
+    TooltipArrow,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { Lightbulb } from "lucide-react";
 
 type Props = {
     id?: string;
     title?: string;
+    tooltipContent?: React.ReactNode;
     readonly className?: string;
     readonly children: React.ReactNode;
 };
@@ -14,6 +21,7 @@ type Props = {
 export default function CardWrapperInfoAmbientes({
     id,
     title = "Disponibilidade do ambiente",
+    tooltipContent,
     className,
     children,
 }: Readonly<Props>) {
@@ -23,7 +31,31 @@ export default function CardWrapperInfoAmbientes({
                 <CardTitle className="text-lg">
                     {title}
                 </CardTitle>
-                <Lightbulb className="h-6 w-6 text-[#6B7280]" />
+                {tooltipContent ? (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                type="button"
+                                className="cursor-help"
+                                aria-label={`Informações sobre ${title}`}
+                            >
+                                <Lightbulb className="h-6 w-6 text-[#6B7280]" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent
+                            side="right"
+                            sideOffset={12}
+                            className="max-w-sm bg-[#111827] text-white border-none p-4 rounded-lg shadow-lg"
+                        >
+                            <TooltipArrow className="text-[#111827]" width={12} height={6} />
+                            <div className="text-sm leading-relaxed">
+                                {tooltipContent}
+                            </div>
+                        </TooltipContent>
+                    </Tooltip>
+                ) : (
+                    <Lightbulb className="h-6 w-6 text-[#6B7280]" />
+                )}
             </CardHeader>
             <CardContent className="px-4 pb-3">
                 <div className="rounded-md ">{children}</div>

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -27,4 +27,16 @@ const TooltipContent = React.forwardRef<
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
-export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }
+const TooltipArrow = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Arrow>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Arrow>
+>(({ className, ...props }, ref) => (
+  <TooltipPrimitive.Arrow
+    ref={ref}
+    className={cn("fill-current", className)}
+    {...props}
+  />
+))
+TooltipArrow.displayName = TooltipPrimitive.Arrow.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipArrow, TooltipProvider }


### PR DESCRIPTION
## Resumo

Implementa tooltips informativos nos ícones de lâmpada presentes nas seções da dashboard, fornecendo contexto e explicações para os usuários.

## Alterações

- Adiciona `TooltipProvider` no layout principal para suporte global de tooltips
- Adiciona componente `TooltipArrow` ao sistema de tooltip existente
- Adiciona prop `tooltipContent` ao componente `CardWrapperInfoAmbientes`
- Implementa tooltips para as seguintes seções:
  - **Disponibilidade do ambiente**: Explica o monitoramento de funcionamento e acessibilidade do sistema
  - **Saúde do servidor (Workloads)**: Descreve o estado de funcionamento, desempenho e estabilidade dos recursos
  - **Bugs**: Informa sobre o registro de bugs e correções do sistema

## Plano de testes

- [ ] Verificar se o tooltip aparece ao passar o mouse sobre o ícone de lâmpada em cada seção
- [ ] Verificar se a seta do tooltip aponta corretamente para o ícone
- [ ] Verificar se o estilo do tooltip está correto (fundo #111827, texto branco)
- [ ] Verificar responsividade do tooltip em diferentes tamanhos de tela