### PR TITLE
Ajustes visuais na dashboard

### DIFF
--- a/src/components/dashboard/BacklogCard.tsx
+++ b/src/components/dashboard/BacklogCard.tsx
@@ -64,7 +64,10 @@ function getWorkItemTypeConfig(workItemType?: string) {
         return { color: "text-[#EF4444]", icon: Bug, label: "HotFix" };
     }
     if (normalized === "bugfix") {
-        return { color: "text-[#3B82F6]", icon: Bug, label: "BugFix" };
+        return { color: "text-[#F97316]", icon: Bug, label: "BugFix" };
+    }
+    if (normalized === "não impeditivo" || normalized === "nao impeditivo") {
+        return { color: "text-[#3B82F6]", icon: Bug, label: "Não Impeditivo" };
     }
     if (normalized.includes("bug")) {
         return { color: "text-[#EF4444]", icon: Bug, label: "Bug" };

--- a/src/components/dashboard/JenkinsJobCard.tsx
+++ b/src/components/dashboard/JenkinsJobCard.tsx
@@ -175,13 +175,13 @@ export default function JenkinsJobCard({
             <Header {...headerProps} />
             
             <div className="space-y-3">
-                <div className="bg-[#F5F5F5] rounded-[5px] p-4 flex items-center gap-3">
-                    <Clock className="w-6 h-6 text-[#3B82F6] flex-shrink-0" />
+                <div className="bg-[#DCFCE7] rounded-[5px] p-4 flex items-center gap-3">
+                    <Clock className="w-6 h-6 text-[#22C55E] flex-shrink-0" />
                     <div>
                         <div className="font-bold text-[14px] text-[#111827]">
                             v{lastReleasedVersion.number}
                         </div>
-                        <div className="text-[12px] text-[#6B7280]">
+                        <div className="text-[12px] text-[#166534]">
                             Realizado em: {lastReleasedVersion.timestamp}
                         </div>
                     </div>


### PR DESCRIPTION
## Resumo
- Versões já lançadas no componente de lançamentos agora aparecem com fundo verde
- Cor do BugFix alterada para laranja no backlog
- Adicionada classificação "Não Impeditivo" em azul no backlog

## Teste
- Verificar na dashboard se versões lançadas aparecem em verde
- Verificar se versões agendadas permanecem com fundo cinza
- Verificar cores dos tipos de trabalho no backlog