### PR TITLE
feat: adiciona botão de fechar no modal de boas-vindas

### DIFF
--- a/src/components/dashboard/Onboarding/WelcomeModal.test.tsx
+++ b/src/components/dashboard/Onboarding/WelcomeModal.test.tsx
@@ -81,4 +81,24 @@ describe("<WelcomeModal />", () => {
         expect(screen.getByText(/preparamos um pequeno tour/i)).toBeInTheDocument();
         expect(screen.getByText(/vamos iniciar\?/i)).toBeInTheDocument();
     });
+
+    it("deve exibir o botão de fechar (X)", () => {
+        useOnboardingStore.setState({ isWelcomeModalOpen: true });
+
+        render(<WelcomeModal />);
+
+        expect(screen.getByRole("button", { name: /fechar/i })).toBeInTheDocument();
+    });
+
+    it("deve fechar o modal ao clicar no botão X", () => {
+        useOnboardingStore.setState({ isWelcomeModalOpen: true });
+
+        render(<WelcomeModal />);
+
+        const closeButton = screen.getByRole("button", { name: /fechar/i });
+        fireEvent.click(closeButton);
+
+        const state = useOnboardingStore.getState();
+        expect(state.isWelcomeModalOpen).toBe(false);
+    });
 });

--- a/src/components/dashboard/Onboarding/WelcomeModal.tsx
+++ b/src/components/dashboard/Onboarding/WelcomeModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
     Dialog,
@@ -14,23 +15,28 @@ import { useOnboarding } from "@/hooks/useOnboarding";
 import { cn } from "@/lib/utils";
 
 export function WelcomeModal() {
-    const { isWelcomeModalOpen, startTour } = useOnboarding();
+    const { isWelcomeModalOpen, startTour, closeWelcomeModal } = useOnboarding();
 
     const handleStartTour = () => {
         startTour();
     };
 
     return (
-        <Dialog open={isWelcomeModalOpen}>
+        <Dialog open={isWelcomeModalOpen} onOpenChange={closeWelcomeModal}>
             <DialogPortal>
                 <DialogOverlay />
                 <DialogPrimitive.Content
                     className={cn(
                         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-[623px] translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-to-left-1/2 data-[state=open]:slide-in-to-top-[48%] sm:rounded-lg"
                     )}
-                    onPointerDownOutside={(e) => e.preventDefault()}
-                    onEscapeKeyDown={(e) => e.preventDefault()}
                 >
+                    <button
+                        onClick={closeWelcomeModal}
+                        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+                        aria-label="Fechar"
+                    >
+                        <X className="h-4 w-4" />
+                    </button>
                     <DialogHeader>
                         <DialogTitle className="text-xl font-[700] text-foreground">
                             Olá, seja bem-vindo(a) ao Autosserviço!


### PR DESCRIPTION
## Summary
- Adiciona botão X no canto superior direito do modal de boas-vindas
- Permite fechar o modal ao clicar no overlay (fora do modal)
- Adiciona testes unitários para as novas funcionalidades

## Test plan
- [ ] Verificar que o botão X aparece no canto superior direito do modal
- [ ] Verificar que clicar no botão X fecha o modal
- [ ] Verificar que clicar fora do modal (no overlay) também fecha o modal
- [ ] Rodar os testes: `npm test -- --run WelcomeModal`