### PR TITLE
Atualiza filas Zabbix para Celery (SigPAE e SigEscola)

### DIFF
--- a/src/components/dashboard/SelectSistemas/getSistemasPorSquad.ts
+++ b/src/components/dashboard/SelectSistemas/getSistemasPorSquad.ts
@@ -14,7 +14,7 @@ const squads: Record<string, Sistema[]> = {
         { id: "7", nome: "Sigla", zabbixQueryFrontend: "", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "", zabbixQueryJenkinsJob: "SME-SIGLA/master", azureDevopsProjectName: "COGEP - Recursos Humanos" },
     ],
     CODAE: [
-        { id: "8", nome: "SigPAE", zabbixQueryFrontend: "PRD - SIGPAE", zabbixQueryBackend: "PRD - SIGPAE - API", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ", zabbixQueryJenkinsJob: "SME-SIGPAE/master", azureDevopsProjectName: "CODAE - Alimentação" },
+        { id: "8", nome: "SigPAE", zabbixQueryFrontend: "PRD - SIGPAE", zabbixQueryBackend: "PRD - SIGPAE - API", zabbixQueryFilasRabbitMQ: "PRD - Celery Sigpae", zabbixQueryJenkinsJob: "SME-SIGPAE/master", azureDevopsProjectName: "CODAE - Alimentação" },
         { id: "9", nome: "Rolê Agroecológico", zabbixQueryFrontend: "", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "", zabbixQueryJenkinsJob: "SME-RoleAgroecologico/master", azureDevopsProjectName: "CODAE - Alimentação" },
     ],
     COPED: [
@@ -26,7 +26,7 @@ const squads: Record<string, Sistema[]> = {
         { id: "15", nome: "IDEP", zabbixQueryFrontend: "PRD - Idep", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "", zabbixQueryJenkinsJob: "SME-IDEP/master", azureDevopsProjectName: "COPED - Pedagógico" },
         { id: "16", nome: "Conecta Formação", zabbixQueryFrontend: "PRD - Conecta Formacao", zabbixQueryBackend: "PRD - Conecta Formacao - API", zabbixQueryFilasRabbitMQ: "PRD - RabbitMQ", zabbixQueryJenkinsJob: "SME-ConectaFormacao/master", azureDevopsProjectName: "EMFORPEF - Formação" },
     ],
-    COPLAN: [{ id: "17", nome: "SigEscola", zabbixQueryFrontend: "PRD - PTRF - SIG Escola", zabbixQueryBackend: "PRD - PTRF - SIG Escola - API", zabbixQueryFilasRabbitMQ: "", zabbixQueryJenkinsJob: "SME-SigEscola/master", azureDevopsProjectName: "COPLAN - PTRF" }],
+    COPLAN: [{ id: "17", nome: "SigEscola", zabbixQueryFrontend: "PRD - PTRF - SIG Escola", zabbixQueryBackend: "PRD - PTRF - SIG Escola - API", zabbixQueryFilasRabbitMQ: "PRD - Celery PTRF", zabbixQueryJenkinsJob: "SME-SigEscola/master", azureDevopsProjectName: "COPLAN - PTRF" }],
     COTIC: [{ id: "18", nome: "Autosserviço", zabbixQueryFrontend: "PRD - AUTOSSERVICO", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "", zabbixQueryJenkinsJob: "SME-Autosservico-Frontend/master", azureDevopsProjectName: "COTIC - Auto Serviço" }],
     GIPE: [{ id: "19", nome: "GIPE", zabbixQueryFrontend: "", zabbixQueryBackend: "", zabbixQueryFilasRabbitMQ: "", zabbixQueryJenkinsJob: "SME-GIPE/master", azureDevopsProjectName: "GIPE - Desenvolvimento" }],
 };


### PR DESCRIPTION
[AB#135587](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/135587)

## Resumo

Atualiza as queries Zabbix de monitoramento de filas para os sistemas que utilizam Celery:

- **SigPAE** (CODAE): `PRD - RabbitMQ` → `PRD - Celery Sigpae`
- **SigEscola** (COPLAN): `""` → `PRD - Celery PTRF`

## Plano de teste

- [ ] Verificar que SigPAE exibe o card "Fila" consultando `PRD - Celery Sigpae`
- [ ] Verificar que SigEscola agora exibe o card "Fila" (antes ficava vazio)
- [ ] Demais sistemas não foram afetados