### PR TITLE
fix(auth): corrige validação de sessão e loading infinito com sessão expirada

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "clsx": "^2.1.1",
     "cpf-cnpj-validator": "^1.0.3",
     "i18next": "^23.11.5",
+    "jose": "^6.1.3",
     "lucide-react": "^0.525.0",
     "next": "14.2.3",
     "next-auth": "^5.0.0-beta.28",

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -11,6 +11,7 @@ import { PageHeader } from "@/components/dashboard/page-header";
 import { SelectSistemas } from "@/components/dashboard/SelectSistemas";
 import { WelcomeModal } from "@/components/dashboard/Onboarding/WelcomeModal";
 import { TourOverlay } from "@/components/dashboard/Onboarding/TourOverlay";
+import { SessionGuard } from "@/components/dashboard/SessionGuard";
 
 export default function DashboardLayout({
     children,
@@ -23,19 +24,21 @@ export default function DashboardLayout({
             refetchOnWindowFocus={false}
             refetchWhenOffline={false}
         >
-            <SidebarProvider>
-                <AppSidebar />
-                <SidebarInset>
-                    <SidebarTrigger className="md:hidden" />
-                    <div id="onboarding-header-section">
-                        <PageHeader />
-                        <SelectSistemas />
-                    </div>
-                    {children}
-                </SidebarInset>
-                <WelcomeModal />
-                <TourOverlay />
-            </SidebarProvider>
+            <SessionGuard>
+                <SidebarProvider>
+                    <AppSidebar />
+                    <SidebarInset>
+                        <SidebarTrigger className="md:hidden" />
+                        <div id="onboarding-header-section">
+                            <PageHeader />
+                            <SelectSistemas />
+                        </div>
+                        {children}
+                    </SidebarInset>
+                    <WelcomeModal />
+                    <TourOverlay />
+                </SidebarProvider>
+            </SessionGuard>
         </SessionProvider>
     );
 }

--- a/src/components/dashboard/SessionGuard.tsx
+++ b/src/components/dashboard/SessionGuard.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useSession, signOut } from "next-auth/react";
+import { useEffect } from "react";
+
+export function SessionGuard({ children }: Readonly<{ children: React.ReactNode }>) {
+    const { status } = useSession();
+
+    useEffect(() => {
+        if (status === "unauthenticated") {
+            signOut({ callbackUrl: "/?expired=true" });
+        }
+    }, [status]);
+
+    if (status === "loading" || status === "unauthenticated") {
+        return (
+            <div className="flex items-center justify-center min-h-screen">
+                <p className="text-gray-500">Carregando...</p>
+            </div>
+        );
+    }
+
+    return <>{children}</>;
+}

--- a/src/components/dashboard/Sidebar/app-sidebar.tsx
+++ b/src/components/dashboard/Sidebar/app-sidebar.tsx
@@ -51,13 +51,22 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
         });
     }, [setActiveItem]);
 
-    // Mostrar loading enquanto não tem dados
     if (allowedItems.length === 0) {
         return (
             <Sidebar collapsible="icon" data-testid="sidebar-root" {...props} className="m-2">
                 <SidebarContent>
-                    <div className="p-4">Carregando...</div>
+                    <div className="p-4 text-sm text-gray-500">
+                        Nenhuma coordenadoria disponível para o seu perfil.
+                    </div>
                 </SidebarContent>
+                <SidebarFooter>
+                    <SignOutButton
+                        variant="link"
+                        className="[&_svg]:size-7 text-white no-underline hover:no-underline justify-end"
+                    >
+                        <span>Sair</span> <LogoutIcon />
+                    </SignOutButton>
+                </SidebarFooter>
             </Sidebar>
         );
     }

--- a/src/lib/auth/logic.test.ts
+++ b/src/lib/auth/logic.test.ts
@@ -225,11 +225,13 @@ describe("auth/logic", () => {
         expect(typeof out.exp).toBe("number");
     });
 
-    it("jwtCallback retorna token inalterado quando user ausente", () => {
+    it("jwtCallback renova exp mesmo quando user ausente (sliding session)", () => {
         const token: JWT = { foo: "bar" } as unknown as JWT;
         const out = jwtCallback({ token });
         expect(out).toBe(token);
         expect((out as Record<string, unknown>).foo).toBe("bar");
+        expect(out.exp).toBeDefined();
+        expect(typeof out.exp).toBe("number");
     });
 
     // ---------- sessionCallback ----------

--- a/src/lib/auth/logic.ts
+++ b/src/lib/auth/logic.ts
@@ -22,7 +22,6 @@ export async function authorizeUser(
         senha: credentials.password as string,
     }, loginVersion);
 
-    console.log("XXXXXXXXXXXxx Login response:", loginResponse);
     if (loginResponse.status === 401 || (!loginResponse.nome && loginResponse.detail)) {
         throw new Error(PERFIL_NOT_FOUND_ERROR_MESSAGE);
     }
@@ -87,8 +86,9 @@ export function jwtCallback({ token, user }: { token: JWT; user?: User }): JWT {
         token.groups = user.groups;
         token.given_name = user.given_name;
         token.family_name = user.family_name;
-        token.exp = Math.floor(Date.now() / 1000) + TOKEN_MAX_AGE_SECONDS;
     }
+
+    token.exp = Math.floor(Date.now() / 1000) + TOKEN_MAX_AGE_SECONDS;
     return token;
 }
 

--- a/src/lib/auth/strategies/index.test.ts
+++ b/src/lib/auth/strategies/index.test.ts
@@ -7,12 +7,14 @@ vi.mock("@/lib/axios", () => ({
     autenticaCoreSSO: { post: vi.fn() },
     autenticaKeycloak: { post: vi.fn() },
 }));
-vi.mock("../../utils", () => ({
-    decodeJwt: vi.fn(() => ({ name: "Nome", preferred_username: "user", groups: ["G1"] })),
+
+const mockJwtVerify = vi.fn();
+vi.mock("jose", () => ({
+    createRemoteJWKSet: vi.fn(() => "mock-jwks"),
+    jwtVerify: (...args: unknown[]) => mockJwtVerify(...args),
 }));
 
 import { autenticaCoreSSO, autenticaKeycloak } from "@/lib/axios";
-import { decodeJwt } from "../../utils";
 
 describe("loginCoreSSO", () => {
     const OLD_ENV = process.env;
@@ -123,9 +125,11 @@ describe("loginKeycloak", () => {
         await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow();
     });
 
-    it("retorna payload decodificado e token em caso de sucesso", async () => {
+    it("retorna payload verificado com assinatura válida e token em caso de sucesso", async () => {
         vi.mocked(autenticaKeycloak.post).mockResolvedValueOnce({ data: { access_token: "tok123" } });
-        vi.mocked(decodeJwt).mockReturnValueOnce({ name: "Nome", preferred_username: "user", groups: ["G1"] });
+        mockJwtVerify.mockResolvedValueOnce({
+            payload: { name: "Nome", preferred_username: "user", groups: ["G1"] },
+        });
         const resp = await loginKeycloak({ login: "a", senha: "b" });
         expect(resp).toMatchObject({ name: "Nome", preferred_username: "user", groups: ["G1"], keycloakToken: "tok123" });
         expect(autenticaKeycloak.post).toHaveBeenCalledWith(
@@ -133,6 +137,7 @@ describe("loginKeycloak", () => {
             expect.any(URLSearchParams),
             expect.objectContaining({ headers: { "Content-Type": "application/x-www-form-urlencoded" } })
         );
+        expect(mockJwtVerify).toHaveBeenCalledWith("tok123", "mock-jwks");
     });
 
     it("retorna status e detail em erro AxiosError com response", async () => {

--- a/src/lib/auth/strategies/index.ts
+++ b/src/lib/auth/strategies/index.ts
@@ -1,7 +1,7 @@
 import { autenticaCoreSSO, autenticaKeycloak } from "@/lib/axios";
 import { AxiosError } from "axios";
 import { LoginData, LoginResponse } from "@/types/login";
-import { decodeJwt } from "../../utils";
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 
 export async function loginCoreSSO(data: LoginData): Promise<LoginResponse> {
     if (!process.env.AUTENTICA_CORESSO_API_URL) {
@@ -30,12 +30,39 @@ export async function loginCoreSSO(data: LoginData): Promise<LoginResponse> {
     }
 }
 
+async function verifyKeycloakJwt(
+    token: string,
+    keycloakUrl: string,
+    realm: string,
+): Promise<JWTPayload> {
+    const jwksUrl = new URL(
+        `/realms/${realm}/protocol/openid-connect/certs`,
+        keycloakUrl,
+    );
+    const jwks = createRemoteJWKSet(jwksUrl);
+    const { payload } = await jwtVerify(token, jwks);
+    return payload;
+}
+
 export async function loginKeycloak(data: LoginData): Promise<LoginResponse> {
-    // Parâmetros fixos ou de env
-    const clientId = process.env.KEYCLOAK_CLIENT_ID ?? "nome-do-projeto";
+    if (!process.env.KEYCLOAK_URL) {
+        throw new Error("KEYCLOAK_URL não está definida");
+    }
+    if (!process.env.KEYCLOAK_CLIENT_ID) {
+        throw new Error("KEYCLOAK_CLIENT_ID não está definida");
+    }
+    if (!process.env.KEYCLOAK_CLIENT_SECRET) {
+        throw new Error("KEYCLOAK_CLIENT_SECRET não está definida");
+    }
+    if (!process.env.KEYCLOAK_REALM) {
+        throw new Error("KEYCLOAK_REALM não está definida");
+    }
+
+    const keycloakUrl = process.env.KEYCLOAK_URL;
+    const clientId = process.env.KEYCLOAK_CLIENT_ID;
     const grantType = process.env.KEYCLOAK_GRANT_TYPE ?? "password";
-    const clientSecret = process.env.KEYCLOAK_CLIENT_SECRET ?? "secret-key";
-    const realm = process.env.KEYCLOAK_REALM ?? "SQUAD";
+    const clientSecret = process.env.KEYCLOAK_CLIENT_SECRET;
+    const realm = process.env.KEYCLOAK_REALM;
     const password = data.senha;
     const username = data.login;
 
@@ -48,20 +75,23 @@ export async function loginKeycloak(data: LoginData): Promise<LoginResponse> {
     });
 
     try {
-
         const headersKeycloak = {
             "Content-Type": "application/x-www-form-urlencoded",
         };
 
-        const keycloakResponse = await autenticaKeycloak.post(`/realms/${realm}/protocol/openid-connect/token`, dataKeycloak, { headers: headersKeycloak });
-        // Decodifica o payload do token se necessário
+        const keycloakResponse = await autenticaKeycloak.post(
+            `/realms/${realm}/protocol/openid-connect/token`,
+            dataKeycloak,
+            { headers: headersKeycloak },
+        );
+
         const accessToken = keycloakResponse.data.access_token;
-        const payloadJson = decodeJwt(accessToken);
-        // Retorne o que for necessário para o LoginResponse
+        const payload = await verifyKeycloakJwt(accessToken, keycloakUrl, realm);
+
         return {
-            ...payloadJson,
+            ...payload,
             keycloakToken: accessToken,
-        };
+        } as LoginResponse;
     } catch (e) {
         if (e instanceof AxiosError && e.response) {
             return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3351,6 +3351,11 @@ jose@^6.0.6:
   resolved "https://registry.yarnpkg.com/jose/-/jose-6.0.11.tgz#0b7ea8b3b21a1bda5e00255a044c3a0e43270882"
   integrity sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==
 
+jose@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/jose/-/jose-6.1.3.tgz#8453d7be88af7bb7d64a0481d6a35a0145ba3ea5"
+  integrity sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## Resumo

- Removido `console.log` que vazava dados sensíveis (tokens, CPF, grupos) nos logs de produção
- Substituídos fallbacks fictícios do Keycloak (`"secret-key"`, `"nome-do-projeto"`) por validação fail-fast das variáveis de ambiente
- Corrigido sliding session: `exp` do JWT agora é renovado em toda chamada do `jwtCallback`, não apenas no primeiro login
- Substituído `decodeJwt` (base64 sem verificação de assinatura) por `jose.jwtVerify` com endpoint JWKS do Keycloak
- Adicionado `SessionGuard` no layout do dashboard para redirecionar ao login quando a sessão expira no client-side
- Atualizada mensagem da sidebar para perfis sem coordenadorias disponíveis

## Detalhes técnicos

### Segurança
| Item | Antes | Depois |
|------|-------|--------|
| Dados sensíveis em log | `console.log("XXX Login response:", ...)` | Removido |
| Env vars Keycloak | Fallback para `"secret-key"` | `throw Error` se ausente |
| JWT Keycloak | `decodeJwt` (base64, sem verificação) | `jwtVerify` + JWKS |

### Sessão
| Item | Antes | Depois |
|------|-------|--------|
| Renovação do token | Apenas no primeiro login | Toda chamada do callback (sliding) |
| Sessão expirada (client) | Loading infinito | Redirect para `/?expired=true` |
| Sidebar sem squads | "Carregando..." eterno | Mensagem informativa + botão Sair |

### Dependência adicionada
- `jose` (validação JWT, zero dependências, já usada internamente pelo NextAuth)

## Plano de testes

- [x] 417 testes passando (46 arquivos)
- [ ] Testar login v1 (CORESSO) com credenciais válidas
- [ ] Testar login v2 (Keycloak) com credenciais válidas
- [ ] Verificar que sessão expirada redireciona para login com `?expired=true`
- [ ] Verificar que sidebar mostra mensagem correta para usuário sem squads
- [ ] Verificar que sessão é renovada automaticamente durante uso ativo