### PR TITLE
feat(dashboard): monitoramento de banco de dados via Zabbix

### DIFF
--- a/src/actions/_helpers/databaseConfig.test.ts
+++ b/src/actions/_helpers/databaseConfig.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { getDatabaseConfigForSystem, systemHasNoDatabase } from "./databaseConfig";
+
+describe("getDatabaseConfigForSystem", () => {
+  it("retorna config correta para sistema MySQL (Portal Educação)", () => {
+    const config = getDatabaseConfigForSystem("Portal Educação");
+    expect(config).not.toBeNull();
+    expect(config).toHaveLength(1);
+    expect(config![0].dbType).toBe("mysql");
+    expect(config![0].hostid).toBe("10641");
+    expect(config![0].key).toBe("mysql.ping");
+  });
+
+  it("retorna config correta para sistema PostgreSQL com role (Novo SGP → 2 entries)", () => {
+    const config = getDatabaseConfigForSystem("Novo SGP");
+    expect(config).not.toBeNull();
+    expect(config).toHaveLength(2);
+    expect(config![0].dbType).toBe("postgresql");
+    expect(config![0].role).toBe("escrita");
+    expect(config![0].label).toBe("PostgreSQL (Escrita)");
+    expect(config![1].role).toBe("leitura");
+    expect(config![1].label).toBe("PostgreSQL (Leitura)");
+  });
+
+  it("retorna config correta para SQL Server (Serap)", () => {
+    const config = getDatabaseConfigForSystem("Serap");
+    expect(config).not.toBeNull();
+    expect(config).toHaveLength(1);
+    expect(config![0].dbType).toBe("sqlserver");
+    expect(config![0].hostid).toBe("10711");
+  });
+
+  it("retorna null para sistema sem banco (Escolhas)", () => {
+    const config = getDatabaseConfigForSystem("Escolhas");
+    expect(config).toBeNull();
+  });
+
+  it("retorna null para sistema inexistente", () => {
+    const config = getDatabaseConfigForSystem("Sistema Fantasma");
+    expect(config).toBeNull();
+  });
+});
+
+describe("systemHasNoDatabase", () => {
+  it("retorna true para Escolhas (config vazia)", () => {
+    expect(systemHasNoDatabase("Escolhas")).toBe(true);
+  });
+
+  it("retorna false para sistema inexistente", () => {
+    expect(systemHasNoDatabase("Sistema Fantasma")).toBe(false);
+  });
+
+  it("retorna false para sistema com banco", () => {
+    expect(systemHasNoDatabase("Novo SGP")).toBe(false);
+  });
+});
+
+describe("isOk validation rules", () => {
+  it("MySQL: lastvalue '1' → true, '0' → false", () => {
+    const config = getDatabaseConfigForSystem("Portal Educação")!;
+    expect(config[0].isOk("1")).toBe(true);
+    expect(config[0].isOk("0")).toBe(false);
+  });
+
+  it("PostgreSQL: lastvalue '0' → true, '1' → false", () => {
+    const config = getDatabaseConfigForSystem("SigPAE")!;
+    expect(config[0].isOk("0")).toBe(true);
+    expect(config[0].isOk("1")).toBe(false);
+  });
+
+  it("SQL Server: lastvalue '0' → true, '1' → false", () => {
+    const config = getDatabaseConfigForSystem("Serap")!;
+    expect(config[0].isOk("0")).toBe(true);
+    expect(config[0].isOk("1")).toBe(false);
+  });
+});

--- a/src/actions/_helpers/databaseConfig.ts
+++ b/src/actions/_helpers/databaseConfig.ts
@@ -1,0 +1,80 @@
+export type DbCheckConfig = {
+  label: string;
+  hostid: string;
+  key: string;
+  dbType: "mysql" | "postgresql" | "sqlserver";
+  role?: "escrita" | "leitura";
+  isOk: (lastvalue: string) => boolean;
+};
+
+const mysqlPing = (lastvalue: string) => lastvalue === "1";
+const psqlRunning = (lastvalue: string) => lastvalue === "0";
+const sqlServerRunning = (lastvalue: string) => lastvalue === "0";
+
+const DATABASE_CONFIG: Record<string, DbCheckConfig[]> = {
+  "Portal Educação": [
+    { label: "MySQL", hostid: "10641", key: "mysql.ping", dbType: "mysql", isOk: mysqlPing },
+  ],
+  "Portal CEU": [
+    { label: "MySQL", hostid: "10641", key: "mysql.ping", dbType: "mysql", isOk: mysqlPing },
+  ],
+  Intranet: [
+    { label: "MySQL", hostid: "10641", key: "mysql.ping", dbType: "mysql", isOk: mysqlPing },
+  ],
+  "Rolê Agroecológico": [
+    { label: "MySQL", hostid: "10641", key: "mysql.ping", dbType: "mysql", isOk: mysqlPing },
+  ],
+  Plateia: [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  "Plateia App": [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  SigPAE: [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  Cdep: [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  "Currículo da Cidade": [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  IDEP: [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  "Conecta Formação": [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  SigEscola: [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  GIPE: [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  Sigla: [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  "Novo SGP": [
+    { label: "PostgreSQL (Escrita)", hostid: "10747", key: "psql.running", dbType: "postgresql", role: "escrita", isOk: psqlRunning },
+    { label: "PostgreSQL (Leitura)", hostid: "10745", key: "psql.running", dbType: "postgresql", role: "leitura", isOk: psqlRunning },
+  ],
+  "Serap Estudantes": [
+    { label: "PostgreSQL (Escrita)", hostid: "10673", key: "psql.running", dbType: "postgresql", role: "escrita", isOk: psqlRunning },
+    { label: "PostgreSQL (Leitura)", hostid: "10674", key: "psql.running", dbType: "postgresql", role: "leitura", isOk: psqlRunning },
+  ],
+  Serap: [
+    { label: "SQL Server", hostid: "10711", key: 'service.info["MSSQL$SME_PRD",state]', dbType: "sqlserver", isOk: sqlServerRunning },
+  ],
+  Escolhas: [],
+};
+
+export function getDatabaseConfigForSystem(systemName: string): DbCheckConfig[] | null {
+  const config = DATABASE_CONFIG[systemName];
+  if (config === undefined) return null;
+  if (config.length === 0) return null;
+  return config;
+}
+
+export function systemHasNoDatabase(systemName: string): boolean {
+  return systemName in DATABASE_CONFIG && DATABASE_CONFIG[systemName].length === 0;
+}

--- a/src/actions/_helpers/databaseStatus.test.ts
+++ b/src/actions/_helpers/databaseStatus.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchDatabaseStatus } from "./databaseStatus";
+
+vi.mock("@/lib/zabbix.server", () => ({
+  zabbixRpc: vi.fn(),
+}));
+
+import { zabbixRpc } from "@/lib/zabbix.server";
+
+const mockZabbixRpc = vi.mocked(zabbixRpc);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("fetchDatabaseStatus", () => {
+  it("sistema sem banco (Escolhas) → hasDatabase: false", async () => {
+    const result = await fetchDatabaseStatus("Escolhas");
+    expect(result.hasDatabase).toBe(false);
+    expect(result.instances).toEqual([]);
+    expect(mockZabbixRpc).not.toHaveBeenCalled();
+  });
+
+  it("sistema inexistente → hasDatabase: false", async () => {
+    const result = await fetchDatabaseStatus("Sistema Fantasma");
+    expect(result.hasDatabase).toBe(false);
+    expect(result.instances).toEqual([]);
+  });
+
+  it("MySQL com lastvalue '1' → available: true", async () => {
+    mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "1" }]);
+
+    const result = await fetchDatabaseStatus("Portal Educação");
+    expect(result.hasDatabase).toBe(true);
+    expect(result.instances).toHaveLength(1);
+    expect(result.instances[0].available).toBe(true);
+    expect(result.instances[0].dbType).toBe("mysql");
+  });
+
+  it("MySQL com lastvalue '0' → available: false", async () => {
+    mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "0" }]);
+
+    const result = await fetchDatabaseStatus("Portal Educação");
+    expect(result.instances[0].available).toBe(false);
+  });
+
+  it("PostgreSQL com lastvalue '0' → available: true", async () => {
+    mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "0" }]);
+
+    const result = await fetchDatabaseStatus("SigPAE");
+    expect(result.instances[0].available).toBe(true);
+    expect(result.instances[0].dbType).toBe("postgresql");
+  });
+
+  it("PostgreSQL com lastvalue != '0' → available: false", async () => {
+    mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "1" }]);
+
+    const result = await fetchDatabaseStatus("SigPAE");
+    expect(result.instances[0].available).toBe(false);
+  });
+
+  it("SQL Server com lastvalue '0' → available: true", async () => {
+    mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "0" }]);
+
+    const result = await fetchDatabaseStatus("Serap");
+    expect(result.instances[0].available).toBe(true);
+    expect(result.instances[0].dbType).toBe("sqlserver");
+  });
+
+  it("SQL Server com lastvalue '1' → available: false", async () => {
+    mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "1" }]);
+
+    const result = await fetchDatabaseStatus("Serap");
+    expect(result.instances[0].available).toBe(false);
+  });
+
+  it("sistema com 2 instâncias (Novo SGP) → retorna 2 entries com roles", async () => {
+    mockZabbixRpc
+      .mockResolvedValueOnce([{ itemid: "1", lastvalue: "0" }])
+      .mockResolvedValueOnce([{ itemid: "2", lastvalue: "0" }]);
+
+    const result = await fetchDatabaseStatus("Novo SGP");
+    expect(result.hasDatabase).toBe(true);
+    expect(result.instances).toHaveLength(2);
+    expect(result.instances[0].label).toBe("PostgreSQL (Escrita)");
+    expect(result.instances[0].role).toBe("escrita");
+    expect(result.instances[0].available).toBe(true);
+    expect(result.instances[1].label).toBe("PostgreSQL (Leitura)");
+    expect(result.instances[1].role).toBe("leitura");
+    expect(result.instances[1].available).toBe(true);
+  });
+
+  it("erro na chamada Zabbix → instância retorna available: false", async () => {
+    mockZabbixRpc.mockRejectedValueOnce(new Error("Zabbix timeout"));
+
+    const result = await fetchDatabaseStatus("Portal Educação");
+    expect(result.hasDatabase).toBe(true);
+    expect(result.instances[0].available).toBe(false);
+  });
+});

--- a/src/actions/_helpers/databaseStatus.ts
+++ b/src/actions/_helpers/databaseStatus.ts
@@ -1,0 +1,54 @@
+import { zabbixRpc } from "@/lib/zabbix.server";
+import { getDatabaseConfigForSystem, systemHasNoDatabase } from "./databaseConfig";
+import type { DatabaseStatusResponse } from "@/types/database";
+
+type ZabbixItem = {
+  itemid: string;
+  lastvalue: string;
+  [key: string]: unknown;
+};
+
+export async function fetchDatabaseStatus(systemName: string): Promise<DatabaseStatusResponse> {
+  if (systemHasNoDatabase(systemName)) {
+    return { system: systemName, hasDatabase: false, instances: [] };
+  }
+
+  const configs = getDatabaseConfigForSystem(systemName);
+
+  if (!configs) {
+    return { system: systemName, hasDatabase: false, instances: [] };
+  }
+
+  const results = await Promise.all(
+    configs.map(async (cfg) => {
+      try {
+        const items = await zabbixRpc<ZabbixItem[]>("item.get", {
+          hostids: cfg.hostid,
+          search: { key_: cfg.key },
+          output: ["itemid", "lastvalue"],
+        });
+
+        const lastvalue = items?.[0]?.lastvalue ?? "";
+        return {
+          label: cfg.label,
+          dbType: cfg.dbType,
+          available: cfg.isOk(lastvalue),
+          ...(cfg.role ? { role: cfg.role } : {}),
+        };
+      } catch {
+        return {
+          label: cfg.label,
+          dbType: cfg.dbType,
+          available: false,
+          ...(cfg.role ? { role: cfg.role } : {}),
+        };
+      }
+    })
+  );
+
+  return {
+    system: systemName,
+    hasDatabase: true,
+    instances: results,
+  };
+}

--- a/src/app/api/zabbix/database/route.ts
+++ b/src/app/api/zabbix/database/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { fetchDatabaseStatus } from "@/actions/_helpers/databaseStatus";
+
+export const runtime = "nodejs";
+export const revalidate = 0;
+
+export async function GET(req: NextRequest) {
+  const session = await auth();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { searchParams } = new URL(req.url);
+  const system = (searchParams.get("system") ?? "").trim();
+
+  if (!system) return NextResponse.json({ error: "system é obrigatório" }, { status: 400 });
+
+  try {
+    const status = await fetchDatabaseStatus(system);
+    return NextResponse.json(status);
+  } catch (e: unknown) {
+    const errorMessage =
+      typeof e === "object" && e !== null && "message" in e
+        ? (e as { message?: string }).message
+        : "Erro ao consultar status do banco de dados";
+    return NextResponse.json({ error: errorMessage ?? "Erro ao consultar status do banco de dados" }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -63,6 +63,13 @@ vi.mock("@/components/dashboard/JenkinsJob", () => ({
   ),
 }));
 
+vi.mock("@/components/dashboard/DatabaseStatusCard", () => ({
+  __esModule: true,
+  default: ({ systemName }: { systemName?: string }) => (
+    <div data-testid="database-status-card">{systemName ?? ""}</div>
+  ),
+}));
+
 describe("Dashboard page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -93,6 +100,9 @@ describe("Dashboard page", () => {
 
     // Jenkins (não está envolto em CardWrapperInfoAmbientes)
     expect(screen.getByTestId("jenkins-Lançamento de Versões")).toHaveTextContent("Novo SGP::0");
+
+    // Banco de dados
+    expect(screen.getByTestId("database-status-card")).toHaveTextContent("Novo SGP");
   });
 
   test("quando não há projeto ativo, passa strings vazias para os filhos (ramo do ??)", () => {
@@ -104,6 +114,7 @@ describe("Dashboard page", () => {
     expect(screen.getByTestId("producao-API Service")).toHaveTextContent("");
     expect(screen.getByTestId("filas-Fila")).toHaveTextContent("");
     expect(screen.getByTestId("jenkins-Lançamento de Versões")).toHaveTextContent("::0");
+    expect(screen.getByTestId("database-status-card")).toHaveTextContent("");
   });
 
   test("trima os nomes antes de passar (ramo do ?.trim())", () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,6 +2,7 @@
 import CardWrapperInfoAmbientes from "@/components/dashboard/CardWrapperInfoAmbientes";
 import Producao from "@/components/dashboard/DisponibilidadeDosAmbientes/Producao";
 import Filas from "@/components/dashboard/SaudeDosServidores/Filas";
+import DatabaseStatusCard from "@/components/dashboard/DatabaseStatusCard";
 import JenkinsJob from "@/components/dashboard/JenkinsJob";
 import AzureDevOpsBacklog from "@/components/dashboard/AzureDevOpsBacklog";
 import useDashboardStore from "@/states/dashboard";
@@ -73,6 +74,20 @@ export default function Dashboard() {
                         className="bg-[#F5F5F5] p-3"
                         projectName={projectNameBackEnd ?? ""}
                     />
+                </CardWrapperInfoAmbientes>
+
+                <CardWrapperInfoAmbientes
+                    id="onboarding-banco-dados"
+                    title="Banco de dados"
+                    className="max-w-sm"
+                    tooltipContent={
+                        <p>
+                            Essa seção monitora o estado de saúde e disponibilidade
+                            dos bancos de dados utilizados pelo sistema.
+                        </p>
+                    }
+                >
+                    <DatabaseStatusCard systemName={projectName ?? ""} className="bg-[#F5F5F5] p-3" />
                 </CardWrapperInfoAmbientes>
             </div>
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -82,8 +82,8 @@ export default function Dashboard() {
                     className="max-w-sm"
                     tooltipContent={
                         <p>
-                            Essa seção monitora o estado de saúde e disponibilidade
-                            dos bancos de dados utilizados pelo sistema.
+                            Nesta seção você acompanhará a comunicação do sistema com
+                            os bancos de dados e informações das aplicações.
                         </p>
                     }
                 >

--- a/src/components/dashboard/DatabaseStatusCard.test.tsx
+++ b/src/components/dashboard/DatabaseStatusCard.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { DatabaseStatusResponse } from "@/types/database";
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: (props: React.HTMLAttributes<HTMLDivElement>) => (
+    <div data-testid="skeleton" {...props} />
+  ),
+}));
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...rest
+  }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button data-testid="retry-button" {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+type MockQueryResult = {
+  data?: DatabaseStatusResponse;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => void;
+};
+
+let mockQueryResult: MockQueryResult = {
+  data: undefined,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+
+vi.mock("@/hooks/useDatabaseStatus", () => ({
+  useDatabaseStatus: () => mockQueryResult,
+}));
+
+import DatabaseStatusCard from "./DatabaseStatusCard";
+
+describe("<DatabaseStatusCard />", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryResult = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
+  });
+
+  it("sem systemName → mostra 'Selecione um projeto'", () => {
+    render(<DatabaseStatusCard />);
+    expect(screen.getByText("Selecione um projeto")).toBeInTheDocument();
+  });
+
+  it("loading → mostra skeletons", () => {
+    mockQueryResult = { ...mockQueryResult, isLoading: true };
+    render(<DatabaseStatusCard systemName="SigPAE" />);
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("erro → mostra mensagem + botão retry", async () => {
+    const refetch = vi.fn();
+    mockQueryResult = { ...mockQueryResult, isError: true, refetch };
+    render(<DatabaseStatusCard systemName="SigPAE" />);
+
+    expect(screen.getByText("Não foi possível carregar o status.")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("retry-button"));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("sem banco de dados (hasDatabase: false) → mostra 'Sem banco de dados'", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: { system: "Escolhas", hasDatabase: false, instances: [] },
+    };
+    render(<DatabaseStatusCard systemName="Escolhas" />);
+    expect(screen.getByText("Sem banco de dados")).toBeInTheDocument();
+  });
+
+  it("sucesso com 1 instância disponível → mostra título fixo e badge verde", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "Portal Educação",
+        hasDatabase: true,
+        instances: [
+          { label: "MySQL", dbType: "mysql", available: true },
+        ],
+      },
+    };
+    render(<DatabaseStatusCard systemName="Portal Educação" />);
+
+    expect(screen.getByText("Banco de dados principal")).toBeInTheDocument();
+    expect(screen.getByLabelText("Status: Disponível")).toBeInTheDocument();
+    expect(screen.getByText("Disponível")).toBeInTheDocument();
+  });
+
+  it("sucesso com 1 instância indisponível → badge vermelho", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "Portal Educação",
+        hasDatabase: true,
+        instances: [
+          { label: "MySQL", dbType: "mysql", available: false },
+        ],
+      },
+    };
+    render(<DatabaseStatusCard systemName="Portal Educação" />);
+
+    expect(screen.getByLabelText("Status: Indisponível")).toBeInTheDocument();
+    expect(screen.getByText("Indisponível")).toBeInTheDocument();
+  });
+
+  it("sucesso com 2 instâncias (escrita/leitura) → mostra ambas", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "Novo SGP",
+        hasDatabase: true,
+        instances: [
+          { label: "PostgreSQL (Escrita)", dbType: "postgresql", available: true, role: "escrita" },
+          { label: "PostgreSQL (Leitura)", dbType: "postgresql", available: false, role: "leitura" },
+        ],
+      },
+    };
+    render(<DatabaseStatusCard systemName="Novo SGP" />);
+
+    expect(screen.getByText("Banco de dados principal (Escrita)")).toBeInTheDocument();
+    expect(screen.getByText("Banco de dados principal (Leitura)")).toBeInTheDocument();
+    expect(screen.getByLabelText("Status: Disponível")).toBeInTheDocument();
+    expect(screen.getByLabelText("Status: Indisponível")).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/DatabaseStatusCard.tsx
+++ b/src/components/dashboard/DatabaseStatusCard.tsx
@@ -14,8 +14,9 @@ type Props = {
 
 function InstanceBadge({ instance }: { readonly instance: DatabaseInstanceStatus }) {
   const available = instance.available;
+  const roleLabel = instance.role === "escrita" ? "Escrita" : "Leitura";
   const title = instance.role
-    ? `Banco de dados principal (${instance.role === "escrita" ? "Escrita" : "Leitura"})`
+    ? `Banco de dados principal (${roleLabel})`
     : "Banco de dados principal";
 
   return (

--- a/src/components/dashboard/DatabaseStatusCard.tsx
+++ b/src/components/dashboard/DatabaseStatusCard.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Check, XCircle, RotateCcw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { useDatabaseStatus } from "@/hooks/useDatabaseStatus";
+import type { DatabaseInstanceStatus } from "@/types/database";
+
+type Props = {
+  readonly systemName?: string;
+  readonly className?: string;
+};
+
+function InstanceBadge({ instance }: { readonly instance: DatabaseInstanceStatus }) {
+  const available = instance.available;
+  const title = instance.role
+    ? `Banco de dados principal (${instance.role === "escrita" ? "Escrita" : "Leitura"})`
+    : "Banco de dados principal";
+
+  return (
+    <div className="mb-2 last:mb-0 text-center">
+      <div className="font-semibold text-xl">{title}</div>
+      <div className="text-sm text-muted-foreground">Sem incidentes recentes</div>
+      <div
+        className={cn(
+          "mt-1 h-6 w-full rounded-full px-2",
+          "flex items-center justify-center gap-2 text-xs font-medium",
+          available ? "bg-emerald-500 text-white" : "bg-red-500 text-white"
+        )}
+        aria-label={`Status: ${available ? "Disponível" : "Indisponível"}`}
+      >
+        {available ? (
+          <Check className="h-5 w-5" aria-hidden="true" />
+        ) : (
+          <XCircle className="h-5 w-5" aria-hidden="true" />
+        )}
+        {available ? "Disponível" : "Indisponível"}
+      </div>
+    </div>
+  );
+}
+
+export default function DatabaseStatusCard({ systemName, className }: Props) {
+  const { data, isLoading, isFetching, isError, refetch } = useDatabaseStatus({
+    systemName: systemName ?? "",
+  });
+
+  if (!systemName) {
+    return (
+      <div className={cn("text-center", className)}>
+        <div className="text-sm text-muted-foreground">Selecione um projeto</div>
+      </div>
+    );
+  }
+
+  if (isLoading || isFetching) {
+    return (
+      <div className={cn("text-center", className)}>
+        <Skeleton className="mx-auto h-4 w-44" />
+        <Skeleton className="mx-auto mt-3 h-6 w-full rounded-full" />
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className={cn("text-center", className)}>
+        <div className="text-sm text-muted-foreground">Não foi possível carregar o status.</div>
+        <Button onClick={() => refetch()} variant="secondary" size="sm" className="mt-3">
+          <RotateCcw className="mr-2 h-4 w-4" />
+          Tentar novamente
+        </Button>
+      </div>
+    );
+  }
+
+  if (!data.hasDatabase) {
+    return (
+      <div className={cn("text-center", className)}>
+        <div className="text-sm text-muted-foreground">Sem banco de dados</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn(className)}>
+      {data.instances.map((instance) => (
+        <InstanceBadge key={instance.label} instance={instance} />
+      ))}
+    </div>
+  );
+}

--- a/src/hooks/useDatabaseStatus.test.tsx
+++ b/src/hooks/useDatabaseStatus.test.tsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useDatabaseStatus } from "./useDatabaseStatus";
+import type { DatabaseStatusResponse } from "@/types/database";
+
+const createWrapper = () => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          gcTime: Infinity,
+        },
+      },
+    });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+  Wrapper.displayName = "QueryClientTestWrapper";
+  return Wrapper;
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useDatabaseStatus", () => {
+  it("não faz fetch quando systemName é vazio (enabled = false)", async () => {
+    const wrapper = createWrapper();
+    const fetchSpy = vi.spyOn(global, "fetch");
+
+    const { result } = renderHook(
+      () => useDatabaseStatus({ systemName: "" }),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    expect(result.current.isFetching).toBe(false);
+  });
+
+  it("faz fetch com sucesso e retorna dados corretos", async () => {
+    const wrapper = createWrapper();
+    const mockData: DatabaseStatusResponse = {
+      system: "SigPAE",
+      hasDatabase: true,
+      instances: [
+        { label: "PostgreSQL", dbType: "postgresql", available: true },
+      ],
+    };
+
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue({
+        ok: true,
+        json: async () => mockData,
+      } as unknown as Response);
+
+    const { result } = renderHook(
+      () => useDatabaseStatus({ systemName: "SigPAE" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const calledUrl = (fetchSpy.mock.calls[0][0] as string) || "";
+    expect(calledUrl).toBe("/api/zabbix/database?system=SigPAE");
+
+    expect(result.current.data).toEqual(mockData);
+  });
+
+  it("retorna erro quando res.ok === false", async () => {
+    const wrapper = createWrapper();
+
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const { result } = renderHook(
+      () => useDatabaseStatus({ systemName: "SigPAE" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe(
+      "Falha ao buscar status do banco de dados"
+    );
+  });
+});

--- a/src/hooks/useDatabaseStatus.ts
+++ b/src/hooks/useDatabaseStatus.ts
@@ -1,0 +1,22 @@
+import { useQuery } from "@tanstack/react-query";
+import type { DatabaseStatusResponse } from "@/types/database";
+
+type Options = {
+  systemName: string;
+};
+
+export function useDatabaseStatus({ systemName }: Options) {
+  return useQuery<DatabaseStatusResponse>({
+    queryKey: ["database-status", systemName],
+    enabled: !!systemName,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      const qs = new URLSearchParams({ system: systemName });
+      const res = await fetch(`/api/zabbix/database?${qs.toString()}`, {
+        cache: "no-store",
+      });
+      if (!res.ok) throw new Error("Falha ao buscar status do banco de dados");
+      return res.json();
+    },
+  });
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,0 +1,12 @@
+export type DatabaseInstanceStatus = {
+  label: string;
+  dbType: "mysql" | "postgresql" | "sqlserver";
+  available: boolean;
+  role?: "escrita" | "leitura";
+};
+
+export type DatabaseStatusResponse = {
+  system: string;
+  hasDatabase: boolean;
+  instances: DatabaseInstanceStatus[];
+};

--- a/testes/ui/cypress/e2e/ui/banco_dados.feature
+++ b/testes/ui/cypress/e2e/ui/banco_dados.feature
@@ -1,0 +1,27 @@
+# language: pt
+Funcionalidade: Banco de dados - SME AutoServiço
+
+  Contexto:
+    Dado que eu acesso o sistema
+    Quando eu informo o RF do tipo "rf_valido" e a senha do tipo "senha_valida"
+    E clico no botão de acessar
+    Então o resultado esperado para o cenário "Login válido padrão" deve ser exibido
+
+  Cenário: Exibir card de banco de dados no dashboard
+    Então o card de banco de dados deve estar visível
+
+  Cenário: Exibir status do banco ao selecionar sistema com MySQL
+    Quando clico no menu lateral "ASCOM"
+    E seleciono o sistema "Portal Educação" no select
+    Então devo ver o título "Banco de dados principal" no card de banco de dados
+    E devo ver o badge de status no card de banco de dados
+
+  Cenário: Exibir duas instâncias ao selecionar sistema com escrita e leitura
+    Quando clico no menu lateral "COTIC"
+    E seleciono o sistema "Novo SGP" no select
+    Então devo ver 2 badges de status no card de banco de dados
+
+  Cenário: Exibir mensagem para sistema sem banco de dados
+    Quando clico no menu lateral "COTIC"
+    E seleciono o sistema "Escolhas" no select
+    Então devo ver a mensagem "Sem banco de dados" no card

--- a/testes/ui/cypress/support/locators/banco_dados_locators.js
+++ b/testes/ui/cypress/support/locators/banco_dados_locators.js
@@ -1,0 +1,23 @@
+class Banco_Dados_Localizadores {
+
+  card_banco_dados = '#onboarding-banco-dados'
+
+  titulo_banco_dados = '#onboarding-banco-dados .font-semibold'
+
+  descricao_banco_dados = '#onboarding-banco-dados .text-muted-foreground'
+
+  badge_status = '#onboarding-banco-dados [aria-label^="Status:"]'
+
+  texto_sem_banco = '#onboarding-banco-dados .text-muted-foreground'
+
+  botao_tentar_novamente = '#onboarding-banco-dados button'
+
+  botao_cotic = 'span[data-testid="sidebar-button-cotic"]'
+
+  botao_ascom = 'span[data-testid="sidebar-button-ascom"]'
+
+  select_sistema = '#onboarding-select-sistema button'
+
+}
+
+export default Banco_Dados_Localizadores

--- a/testes/ui/cypress/support/step_definitions/banco_dados.js
+++ b/testes/ui/cypress/support/step_definitions/banco_dados.js
@@ -1,0 +1,61 @@
+import { When, Then } from 'cypress-cucumber-preprocessor/steps'
+import Banco_Dados_Localizadores from '../locators/banco_dados_locators'
+
+const locators = new Banco_Dados_Localizadores()
+
+Then('o card de banco de dados deve estar visível', () => {
+  cy.get(locators.card_banco_dados, { timeout: 30000 })
+    .should('be.visible')
+})
+
+When('clico no menu lateral {string}', (menu) => {
+  cy.fecharOverlaySeExistir()
+
+  const menuMap = {
+    'ASCOM': locators.botao_ascom,
+    'COTIC': locators.botao_cotic,
+  }
+
+  const seletor = menuMap[menu]
+
+  cy.get(seletor, { timeout: 30000 })
+    .first()
+    .scrollIntoView()
+    .click({ force: true })
+})
+
+When('seleciono o sistema {string} no select', (sistema) => {
+  cy.fecharOverlaySeExistir()
+
+  cy.get(locators.select_sistema, { timeout: 30000 })
+    .first()
+    .click({ force: true })
+
+  cy.get(`[role="option"]`, { timeout: 10000 })
+    .contains(sistema)
+    .click({ force: true })
+})
+
+Then('devo ver o título {string} no card de banco de dados', (titulo) => {
+  cy.get(locators.titulo_banco_dados, { timeout: 30000 })
+    .first()
+    .should('be.visible')
+    .and('contain.text', titulo)
+})
+
+Then('devo ver o badge de status no card de banco de dados', () => {
+  cy.get(locators.badge_status, { timeout: 30000 })
+    .should('have.length.at.least', 1)
+    .first()
+    .should('be.visible')
+})
+
+Then('devo ver {int} badges de status no card de banco de dados', (quantidade) => {
+  cy.get(locators.badge_status, { timeout: 30000 })
+    .should('have.length', quantidade)
+})
+
+Then('devo ver a mensagem {string} no card', (mensagem) => {
+  cy.get(locators.card_banco_dados, { timeout: 30000 })
+    .should('contain.text', mensagem)
+})


### PR DESCRIPTION
[AB#141363](https://dev.azure.com/SME-Spassu/COTIC%20-%20Auto%20Servi%C3%A7o/_sprints/taskboard/COTIC%20-%20Auto%20Servi%C3%A7o%20Team/COTIC%20-%20Auto%20Servi%C3%A7o/Ciclo%20010%20-%20Mar26?workitem=141363)

## Resumo

- Adiciona monitoramento de status dos bancos de dados (MySQL, PostgreSQL, SQL Server) via `item.get` do Zabbix
- Conecta o card de banco de dados do dashboard a dados reais, substituindo os dados mockados
- Cada sistema é mapeado ao hostid/key correto com regras de interpretação por tipo de banco

## Plano de teste

- [ ] Selecionar sistema com MySQL (ex: Portal Educação) → card mostra 1 instância
- [ ] Selecionar Novo SGP → card mostra 2 instâncias (Escrita e Leitura)
- [ ] Selecionar Serap → card mostra 1 instância SQL Server
- [ ] Selecionar Escolhas → card mostra "Sem banco de dados"
- [ ] Sem projeto selecionado → card mostra "Selecione um projeto"
- [ ] Simular erro de rede → card mostra botão "Tentar novamente"
- [ ] `yarn test` passa sem falhas