### PR TITLE
fix(onboarding): adiciona step de banco de dados no tour

### DIFF
--- a/src/states/onboarding.ts
+++ b/src/states/onboarding.ts
@@ -57,6 +57,15 @@ export const TOUR_STEPS: TourStep[] = [
         centered: true,
     },
     {
+        id: "banco-dados",
+        targetId: "onboarding-banco-dados",
+        title: "Banco de dados",
+        description:
+            "Nesta seção você acompanhará a comunicação do sistema com os bancos de dados e informações das aplicações.",
+        placement: "right",
+        centered: true,
+    },
+    {
         id: "bugs",
         targetId: "onboarding-bugs",
         title: "Bugs",


### PR DESCRIPTION
## Resumo

- Adiciona o step "Banco de dados" no tour de onboarding da dashboard
- O step estava ausente mesmo já existindo o card com `id="onboarding-banco-dados"` na página
- Posicionado antes do step de "Bugs", seguindo a ordem visual da dashboard

## Teste

- Limpar o localStorage (`autosservico-onboarding-completed`) e recarregar a dashboard
- Iniciar o tour e verificar que o step de banco de dados aparece entre "Saúde do servidor" e "Bugs"
- Testes unitários existentes continuam passando