### PR TITLE
fix(dashboard): atualiza texto do step e tooltip de banco de dados

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -81,10 +81,17 @@ export default function Dashboard() {
                     title="Banco de dados"
                     className="max-w-sm"
                     tooltipContent={
-                        <p>
-                            Nesta seção você acompanhará a comunicação do sistema com
-                            os bancos de dados e informações das aplicações.
-                        </p>
+                        <>
+                            <p className="mb-4">
+                                Essa seção acompanha a comunicação do sistema com
+                                os bancos de dados e informações das aplicações.
+                            </p>
+                            <p>
+                                Visa garantir que o banco esteja funcionando bem,
+                                acessível e respondendo corretamente às consultas
+                                das aplicações.
+                            </p>
+                        </>
                     }
                 >
                     <DatabaseStatusCard systemName={projectName ?? ""} className="bg-[#F5F5F5] p-3" />

--- a/src/states/onboarding.ts
+++ b/src/states/onboarding.ts
@@ -61,7 +61,7 @@ export const TOUR_STEPS: TourStep[] = [
         targetId: "onboarding-banco-dados",
         title: "Banco de dados",
         description:
-            "Nesta seção você acompanhará a comunicação do sistema com os bancos de dados e informações das aplicações.",
+            "Essa seção acompanha a comunicação do sistema com os bancos de dados e informações das aplicações. Visa garantir que o banco esteja funcionando bem, acessível e respondendo corretamente às consultas das aplicações.",
         placement: "right",
         centered: true,
     },


### PR DESCRIPTION
## Resumo

- Atualiza o texto do step de banco de dados no tour de onboarding e do tooltip do card na dashboard
- Novo texto descreve melhor o propósito da seção, incluindo a garantia de funcionamento e acessibilidade do banco

## Teste

- Limpar localStorage e iniciar o tour — verificar texto no step de banco de dados
- Passar o mouse no tooltip do card "Banco de dados" — verificar texto atualizado