### PR TITLE
fix(testes): corrige testes cypress de banco de dados

### DIFF
--- a/testes/ui/cypress/e2e/ui/banco_dados.feature
+++ b/testes/ui/cypress/e2e/ui/banco_dados.feature
@@ -13,15 +13,15 @@ Funcionalidade: Banco de dados - SME AutoServiço
   Cenário: Exibir status do banco ao selecionar sistema com MySQL
     Quando clico no menu lateral "ASCOM"
     E seleciono o sistema "Portal Educação" no select
-    Então devo ver o título "Banco de dados principal" no card de banco de dados
+    Então devo ver o título "Banco de dados" no card de banco de dados
     E devo ver o badge de status no card de banco de dados
 
   Cenário: Exibir duas instâncias ao selecionar sistema com escrita e leitura
-    Quando clico no menu lateral "COTIC"
+    Quando clico no menu lateral "COPED"
     E seleciono o sistema "Novo SGP" no select
     Então devo ver 2 badges de status no card de banco de dados
 
   Cenário: Exibir mensagem para sistema sem banco de dados
-    Quando clico no menu lateral "COTIC"
+    Quando clico no menu lateral "COGEP"
     E seleciono o sistema "Escolhas" no select
     Então devo ver a mensagem "Sem banco de dados" no card

--- a/testes/ui/cypress/support/locators/banco_dados_locators.js
+++ b/testes/ui/cypress/support/locators/banco_dados_locators.js
@@ -16,6 +16,10 @@ class Banco_Dados_Localizadores {
 
   botao_ascom = 'span[data-testid="sidebar-button-ascom"]'
 
+  botao_coped = 'span[data-testid="sidebar-button-coped"]'
+
+  botao_cogep = 'span[data-testid="sidebar-button-cogep"]'
+
   select_sistema = '#onboarding-select-sistema button'
 
 }

--- a/testes/ui/cypress/support/step_definitions/banco_dados.js
+++ b/testes/ui/cypress/support/step_definitions/banco_dados.js
@@ -14,6 +14,8 @@ When('clico no menu lateral {string}', (menu) => {
   const menuMap = {
     'ASCOM': locators.botao_ascom,
     'COTIC': locators.botao_cotic,
+    'COPED': locators.botao_coped,
+    'COGEP': locators.botao_cogep,
   }
 
   const seletor = menuMap[menu]


### PR DESCRIPTION
## Resumo

- Corrige os 3 cenários falhando em `banco_dados.feature`:
  - Atualiza texto esperado de "Banco de dados principal" para "Banco de dados", refletindo a mudança feita no componente `CardWrapperInfoAmbientes`
  - Corrige a squad utilizada nos cenários: "Novo SGP" pertence à **COPED** (não COTIC) e "Escolhas" pertence à **COGEP** (não COTIC)
  - Adiciona locators e mapeamento de menu para as squads COPED e COGEP

## Plano de teste

- [x] Rodar `npx cypress run` no diretório `testes/ui/` — todos os 12 testes passam
- [x] Verificar que os cenários de banco de dados selecionam os sistemas nas squads corretas