### PR TITLE
Força indisponibilidade do MySQL para teste

### DIFF
--- a/src/actions/_helpers/databaseStatus.test.ts
+++ b/src/actions/_helpers/databaseStatus.test.ts
@@ -27,17 +27,17 @@ describe("fetchDatabaseStatus", () => {
     expect(result.instances).toEqual([]);
   });
 
-  it("MySQL com lastvalue '1' → available: true", async () => {
+  it("MySQL com lastvalue '1' → available: false (hardcoded para teste)", async () => {
     mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "1" }]);
 
     const result = await fetchDatabaseStatus("Portal Educação");
     expect(result.hasDatabase).toBe(true);
     expect(result.instances).toHaveLength(1);
-    expect(result.instances[0].available).toBe(true);
+    expect(result.instances[0].available).toBe(false);
     expect(result.instances[0].dbType).toBe("mysql");
   });
 
-  it("MySQL com lastvalue '0' → available: false", async () => {
+  it("MySQL com lastvalue '0' → available: false (hardcoded para teste)", async () => {
     mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "0" }]);
 
     const result = await fetchDatabaseStatus("Portal Educação");

--- a/src/actions/_helpers/databaseStatus.ts
+++ b/src/actions/_helpers/databaseStatus.ts
@@ -28,7 +28,8 @@ export async function fetchDatabaseStatus(systemName: string): Promise<DatabaseS
           output: ["itemid", "lastvalue"],
         });
 
-        const lastvalue = items?.[0]?.lastvalue ?? "";
+        const lastvalue =
+          cfg.dbType === "mysql" ? "0" : (items?.[0]?.lastvalue ?? "");
         return {
           label: cfg.label,
           dbType: cfg.dbType,

--- a/src/components/dashboard/DatabaseStatusCard.tsx
+++ b/src/components/dashboard/DatabaseStatusCard.tsx
@@ -22,7 +22,9 @@ function InstanceBadge({ instance }: { readonly instance: DatabaseInstanceStatus
   return (
     <div className="mb-2 last:mb-0 text-center">
       <div className="font-semibold text-xl">{title}</div>
-      <div className="text-sm text-muted-foreground">Sem incidentes recentes</div>
+      {available && (
+        <div className="text-sm text-muted-foreground">Sem incidentes recentes</div>
+      )}
       <div
         className={cn(
           "mt-1 h-6 w-full rounded-full px-2",


### PR DESCRIPTION
## Resumo
- Hardcoda o `lastvalue` do MySQL como `"0"` em `databaseStatus.ts` para forçar o status de indisponibilidade no dashboard
- Apenas bancos MySQL são afetados; PostgreSQL e SQL Server continuam com comportamento normal

## Objetivo
Validar visualmente o comportamento do card de banco de dados quando o MySQL está indisponível.

## Plano de teste
- [ ] Acessar o dashboard e selecionar um sistema com MySQL (ex: Portal Educação)
- [ ] Verificar que o badge exibe "Indisponível" em vermelho
- [ ] Selecionar um sistema com PostgreSQL e confirmar que o status continua normal