### PR TITLE
Reverte hardcode e restaura leitura do Zabbix para MySQL

### DIFF
--- a/src/actions/_helpers/databaseStatus.test.ts
+++ b/src/actions/_helpers/databaseStatus.test.ts
@@ -27,17 +27,17 @@ describe("fetchDatabaseStatus", () => {
     expect(result.instances).toEqual([]);
   });
 
-  it("MySQL com lastvalue '1' → available: false (hardcoded para teste)", async () => {
+  it("MySQL com lastvalue '1' → available: true", async () => {
     mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "1" }]);
 
     const result = await fetchDatabaseStatus("Portal Educação");
     expect(result.hasDatabase).toBe(true);
     expect(result.instances).toHaveLength(1);
-    expect(result.instances[0].available).toBe(false);
+    expect(result.instances[0].available).toBe(true);
     expect(result.instances[0].dbType).toBe("mysql");
   });
 
-  it("MySQL com lastvalue '0' → available: false (hardcoded para teste)", async () => {
+  it("MySQL com lastvalue '0' → available: false", async () => {
     mockZabbixRpc.mockResolvedValueOnce([{ itemid: "1", lastvalue: "0" }]);
 
     const result = await fetchDatabaseStatus("Portal Educação");

--- a/src/actions/_helpers/databaseStatus.ts
+++ b/src/actions/_helpers/databaseStatus.ts
@@ -28,8 +28,7 @@ export async function fetchDatabaseStatus(systemName: string): Promise<DatabaseS
           output: ["itemid", "lastvalue"],
         });
 
-        const lastvalue =
-          cfg.dbType === "mysql" ? "0" : (items?.[0]?.lastvalue ?? "");
+        const lastvalue = items?.[0]?.lastvalue ?? "";
         return {
           label: cfg.label,
           dbType: cfg.dbType,


### PR DESCRIPTION
## Resumo
- Remove o `lastvalue` hardcoded como `"0"` para MySQL, restaurando a leitura normal do Zabbix
- Restaura os testes unitários ao comportamento original
- Mantém a melhoria de ocultar "Sem incidentes recentes" quando o banco está indisponível (já mergeada na PR #99)

## Plano de teste
- [ ] Verificar que sistemas MySQL (ex: Portal Educação) exibem status real do Zabbix
- [ ] Verificar que "Sem incidentes recentes" continua oculto quando banco indisponível
- [ ] Rodar `yarn test` — 448/448 passando