### PR TITLE
feat(dashboard): adiciona indicador de usuários ativos por produto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 
 # testing
 /coverage
+/.scannerwork
 
 # next.js
 /.next/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,29 @@
-# Excluir arquivo que usa Tailwind CSS das análises do SonarQube
-sonar.exclusions=src/styles/globals.scss
+# Caminho do relatório de cobertura LCOV gerado pelo Vitest
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+
+# Excluir arquivos de teste da análise principal
+sonar.exclusions=src/styles/globals.scss,src/**/*.test.ts,src/**/*.test.tsx,src/**/*.spec.ts,src/**/*.spec.tsx,src/**/__tests__/**,src/__mocks__/**,src/setupTests.ts,src/lib/zod-i18n.ts,src/types/**,src/components/ui/**,src/assets/icons/**
+
+# Arquivos excluídos da análise de cobertura (alinhado com vitest.config.ts)
+sonar.coverage.exclusions=\
+  src/components/ui/**,\
+  src/const.ts,\
+  src/app/api/**,\
+  src/lib/auth/__tests__/**,\
+  src/__mocks__/**,\
+  src/types/**,\
+  src/lib/zod-i18n.ts,\
+  src/middleware.ts,\
+  src/setupTests.ts,\
+  src/assets/**,\
+  src/components/dashboard/PeakHoursChart/**,\
+  src/components/dashboard/Sidebar/**,\
+  src/styles/**,\
+  src/app/layout.tsx,\
+  src/app/(login)/page.tsx,\
+  src/components/dashboard/SessionGuard.tsx,\
+  src/lib/QueryProvider.tsx
 
 # Configurações adicionais para ignorar regras CSS específicas
 sonar.issue.ignore.multicriteria=e1,e2

--- a/src/app/dashboard/AzureDevOpsBacklog.test.tsx
+++ b/src/app/dashboard/AzureDevOpsBacklog.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
-import { cleanup } from "@testing-library/react";
+import { render, screen, cleanup } from "@testing-library/react";
 import AzureDevOpsBacklog from "@/components/dashboard/AzureDevOpsBacklog";
 
 // Mock do hook com retorno válido

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,137 +6,159 @@ import DatabaseStatusCard from "@/components/dashboard/DatabaseStatusCard";
 import JenkinsJob from "@/components/dashboard/JenkinsJob";
 import AzureDevOpsBacklog from "@/components/dashboard/AzureDevOpsBacklog";
 import PeakHoursChart from "@/components/dashboard/PeakHoursChart";
+import AverageSessionCard from "@/components/dashboard/AverageSessionCard";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useDashboardStore from "@/states/dashboard";
+
+type FullWidthSectionProps = {
+    readonly id?: string;
+    readonly title: string;
+    readonly tooltip: React.ReactNode;
+    readonly children: React.ReactNode;
+};
+
+function FullWidthSection({ id, title, tooltip, children }: FullWidthSectionProps) {
+    return (
+        <div className="grid grid-cols-4 gap-4">
+            <CardWrapperInfoAmbientes
+                id={id}
+                title={title}
+                className="col-span-4 gap-2 py-2"
+                tooltipContent={tooltip}
+            >
+                {children}
+            </CardWrapperInfoAmbientes>
+        </div>
+    );
+}
 
 export default function Dashboard() {
     const activeProject = useDashboardStore((state) => state.activeProject);
-    const projectNameFrontEnd = activeProject?.zabbixQueryFrontend?.trim();
-    const projectNameBackEnd = activeProject?.zabbixQueryBackend?.trim();
-    const projectNameFilasRabbitMQ = activeProject?.zabbixQueryFilasRabbitMQ?.trim();
-    const projectName = activeProject?.nome?.trim();
+    const projectName = activeProject?.nome?.trim() ?? "";
+    const projectNameFrontEnd = activeProject?.zabbixQueryFrontend?.trim() ?? "";
+    const projectNameBackEnd = activeProject?.zabbixQueryBackend?.trim() ?? "";
+    const projectNameFilasRabbitMQ = activeProject?.zabbixQueryFilasRabbitMQ?.trim() ?? "";
     const jenkinsSubprojects = activeProject?.jenkinsSubprojects ?? [];
 
     return (
         <div className="border-b bg-background px-6 py-4">
-            <div className="grid grid-cols-4 gap-4 mb-4">
-                <div id="onboarding-lancamentos" className="col-span-2">
-                    <JenkinsJob
-                        project={projectName ?? ""}
-                        subprojects={jenkinsSubprojects}
-                    />
-                </div>
-            </div>
-            <div className="grid grid-cols-4 gap-4 mb-4">
-                <CardWrapperInfoAmbientes
-                    id="onboarding-disponibilidade"
-                    title="Disponibilidade do ambiente"
-                    className="max-w-sm"
-                    tooltipContent={
-                        <>
-                            <p className="mb-4">
-                                Essa seção monitora se o sistema está funcionando e acessível aos usuários.
-                                Disponibilidade significa que o sistema está no ar e pronto para uso, sem interrupções.
-                            </p>
+            <Tabs defaultValue="operacional">
+                <TabsList className="mb-6 px-1">
+                    <TabsTrigger value="operacional">Operacional</TabsTrigger>
+                    <TabsTrigger value="analytics">Analytics</TabsTrigger>
+                </TabsList>
+
+                <TabsContent value="operacional">
+                    <div className="grid grid-cols-4 gap-4 mb-4">
+                        <div id="onboarding-lancamentos" className="col-span-2">
+                            <JenkinsJob project={projectName} subprojects={jenkinsSubprojects} />
+                        </div>
+                    </div>
+                    <div className="grid grid-cols-4 gap-4 mb-4">
+                        <CardWrapperInfoAmbientes
+                            id="onboarding-disponibilidade"
+                            title="Disponibilidade do ambiente"
+                            className="max-w-sm"
+                            tooltipContent={
+                                <>
+                                    <p className="mb-4">
+                                        Essa seção monitora se o sistema está funcionando e acessível aos usuários.
+                                        Disponibilidade significa que o sistema está no ar e pronto para uso, sem interrupções.
+                                    </p>
+                                    <p>
+                                        Os ambientes podem estar Disponível, Indisponível ou em Alerta.
+                                    </p>
+                                </>
+                            }
+                        >
+                            <Producao
+                                className="bg-[#F5F5F5] p-3"
+                                projectName={projectNameFrontEnd}
+                            />
+                        </CardWrapperInfoAmbientes>
+
+                        <CardWrapperInfoAmbientes
+                            id="onboarding-saude-servidor"
+                            title="Saúde do servidor (Workloads)"
+                            className="max-w-sm"
+                            tooltipContent={
+                                <>
+                                    <p className="mb-4">
+                                        A saúde de servidores e workloads apontam o estado de funcionamento, desempenho e
+                                        estabilidade dos recursos computacionais que suportam aplicações e serviços de um sistema.
+                                    </p>
+                                    <p>
+                                        O objetivo é garantir que os sistemas estejam disponíveis, performando bem e livres de falhas críticas.
+                                    </p>
+                                </>
+                            }
+                        >
+                            <Filas
+                                title="Fila"
+                                className="mb-5 bg-[#F5F5F5] p-3"
+                                projectName={projectNameFilasRabbitMQ}
+                            />
+                            <Producao
+                                title="API Service"
+                                className="bg-[#F5F5F5] p-3"
+                                projectName={projectNameBackEnd}
+                            />
+                        </CardWrapperInfoAmbientes>
+
+                        <CardWrapperInfoAmbientes
+                            id="onboarding-banco-dados"
+                            title="Banco de dados"
+                            className="max-w-sm"
+                            tooltipContent={
+                                <>
+                                    <p className="mb-4">
+                                        Essa seção acompanha a comunicação do sistema com
+                                        os bancos de dados e informações das aplicações.
+                                    </p>
+                                    <p>
+                                        Visa garantir que o banco esteja funcionando bem,
+                                        acessível e respondendo corretamente às consultas
+                                        das aplicações.
+                                    </p>
+                                </>
+                            }
+                        >
+                            <DatabaseStatusCard systemName={projectName} className="bg-[#F5F5F5] p-3" />
+                        </CardWrapperInfoAmbientes>
+                    </div>
+
+                    <FullWidthSection
+                        id="onboarding-bugs"
+                        title="Bugs"
+                        tooltip={
                             <p>
-                                Os ambientes podem estar Disponível, Indisponível ou em Alerta.
+                                Ao final da página será possível visualizar o registro dos bugs e
+                                correções necessárias para o sistema, suas tratativas e andamento para
+                                resolução.
                             </p>
-                        </>
-                    }
-                >
-                    <Producao
-                        className="bg-[#F5F5F5] p-3"
-                        projectName={projectNameFrontEnd ?? ""}
-                    />
-                </CardWrapperInfoAmbientes>
+                        }
+                    >
+                        <AzureDevOpsBacklog className="p-[2px]" project={projectName} />
+                    </FullWidthSection>
+                </TabsContent>
 
-                <CardWrapperInfoAmbientes
-                    id="onboarding-saude-servidor"
-                    title="Saúde do servidor (Workloads)"
-                    className="max-w-sm"
-                    tooltipContent={
-                        <>
-                            <p className="mb-4">
-                                A saúde de servidores e workloads apontam o estado de funcionamento, desempenho e
-                                estabilidade dos recursos computacionais que suportam aplicações e serviços de um sistema.
-                            </p>
+                <TabsContent value="analytics">
+                    <div className="grid grid-cols-4 gap-4 mb-4">
+                        <AverageSessionCard systemName={projectName} className="max-w-sm" />
+                    </div>
+                    <FullWidthSection
+                        title="Horários de pico"
+                        tooltip={
                             <p>
-                                O objetivo é garantir que os sistemas estejam disponíveis, performando bem e livres de falhas críticas.
+                                Essa seção mostra os horários com maior volume de acessos ao sistema,
+                                permitindo identificar os picos de uso ao longo do dia.
                             </p>
-                        </>
-                    }
-                >
-                    <Filas
-                        title="Fila"
-                        className="mb-5 bg-[#F5F5F5] p-3"
-                        projectName={projectNameFilasRabbitMQ ?? ""}
-                    />
-                    <Producao
-                        title="API Service"
-                        className="bg-[#F5F5F5] p-3"
-                        projectName={projectNameBackEnd ?? ""}
-                    />
-                </CardWrapperInfoAmbientes>
-
-                <CardWrapperInfoAmbientes
-                    id="onboarding-banco-dados"
-                    title="Banco de dados"
-                    className="max-w-sm"
-                    tooltipContent={
-                        <>
-                            <p className="mb-4">
-                                Essa seção acompanha a comunicação do sistema com
-                                os bancos de dados e informações das aplicações.
-                            </p>
-                            <p>
-                                Visa garantir que o banco esteja funcionando bem,
-                                acessível e respondendo corretamente às consultas
-                                das aplicações.
-                            </p>
-                        </>
-                    }
-                >
-                    <DatabaseStatusCard systemName={projectName ?? ""} className="bg-[#F5F5F5] p-3" />
-                </CardWrapperInfoAmbientes>
-            </div>
-
-            <div className="grid grid-cols-4 gap-4 mb-4">
-                <CardWrapperInfoAmbientes
-                    id="onboarding-horarios-pico"
-                    title="Horários de pico"
-                    className="col-span-4 gap-2 py-2"
-                    tooltipContent={
-                        <p>
-                            Essa seção mostra os horários com maior volume de acessos ao sistema,
-                            permitindo identificar os picos de uso ao longo do dia.
-                        </p>
-                    }
-                >
-                    <PeakHoursChart
-                        systemName={projectName ?? ""}
-                        className="p-[2px]"
-                    />
-                </CardWrapperInfoAmbientes>
-            </div>
-
-            <div className="grid grid-cols-4 gap-4">
-                <CardWrapperInfoAmbientes
-                    id="onboarding-bugs"
-                    title="Bugs"
-                    className="col-span-4 gap-2 py-2"
-                    tooltipContent={
-                        <p>
-                            Ao final da página será possível visualizar o registro dos bugs e
-                            correções necessárias para o sistema, suas tratativas e andamento para
-                            resolução.
-                        </p>
-                    }
-                >
-                    <AzureDevOpsBacklog
-                        className="p-[2px]"
-                        project={projectName ?? ""}
-                    />
-                </CardWrapperInfoAmbientes>
-            </div>
+                        }
+                    >
+                        <PeakHoursChart systemName={projectName} className="p-[2px]" />
+                    </FullWidthSection>
+                </TabsContent>
+            </Tabs>
         </div>
     );
 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,6 +7,7 @@ import JenkinsJob from "@/components/dashboard/JenkinsJob";
 import AzureDevOpsBacklog from "@/components/dashboard/AzureDevOpsBacklog";
 import PeakHoursChart from "@/components/dashboard/PeakHoursChart";
 import AverageSessionCard from "@/components/dashboard/AverageSessionCard";
+import ActiveUsersCard from "@/components/dashboard/ActiveUsersCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useDashboardStore from "@/states/dashboard";
 
@@ -145,6 +146,7 @@ export default function Dashboard() {
                 <TabsContent value="analytics">
                     <div className="grid grid-cols-4 gap-4 mb-4">
                         <AverageSessionCard systemName={projectName} className="max-w-sm" />
+                        <ActiveUsersCard systemName={projectName} className="max-w-sm" />
                     </div>
                     <FullWidthSection
                         title="Horários de pico"

--- a/src/components/dashboard/ActiveUsersCard.test.tsx
+++ b/src/components/dashboard/ActiveUsersCard.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ActiveUsersResponse } from "@/types/activeUsers";
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: (props: Readonly<React.HTMLAttributes<HTMLDivElement>>) => (
+    <div data-testid="skeleton" {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...rest
+  }: Readonly<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+    <button data-testid="retry-button" {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+type MockQueryResult = {
+  data?: ActiveUsersResponse;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => void;
+};
+
+let mockQueryResult: MockQueryResult = {
+  data: undefined,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+
+vi.mock("@/hooks/useActiveUsers", () => ({
+  useActiveUsers: () => mockQueryResult,
+}));
+
+import ActiveUsersCard from "./ActiveUsersCard";
+
+describe("<ActiveUsersCard />", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryResult = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
+  });
+
+  it("sem systemName mostra placeholder", () => {
+    render(<ActiveUsersCard />);
+    expect(screen.getByText("Selecione um projeto")).toBeInTheDocument();
+  });
+
+  it("loading mostra skeletons", () => {
+    mockQueryResult = { ...mockQueryResult, isLoading: true };
+    render(<ActiveUsersCard systemName="SigPAE" />);
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("erro mostra mensagem e botão de retry", async () => {
+    const refetch = vi.fn();
+    mockQueryResult = { ...mockQueryResult, isError: true, refetch };
+    render(<ActiveUsersCard systemName="SigPAE" />);
+
+    expect(
+      screen.getByText("Não foi possível carregar os usuários ativos.")
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("retry-button"));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("formata valor em pt-BR e mostra badge 'acima da média' com percentual", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        activeCount: 8398,
+        averageCount: 7563,
+        differencePercentage: 18,
+        trend: "above",
+      },
+    };
+    render(<ActiveUsersCard systemName="SigPAE" />);
+
+    expect(screen.getByText("8.398")).toBeInTheDocument();
+    expect(screen.getByText("18% acima da média")).toBeInTheDocument();
+    expect(screen.getByText(/média: 7\.563/)).toBeInTheDocument();
+  });
+
+  it("mostra 'Na média' sem percentual quando trend = on-average", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        activeCount: 7600,
+        averageCount: 7563,
+        differencePercentage: 0,
+        trend: "on-average",
+      },
+    };
+    render(<ActiveUsersCard systemName="SigPAE" />);
+    expect(screen.getByText("Na média")).toBeInTheDocument();
+  });
+
+  it("mostra 'abaixo da média' com percentual quando trend = below", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        activeCount: 6000,
+        averageCount: 7563,
+        differencePercentage: 20,
+        trend: "below",
+      },
+    };
+    render(<ActiveUsersCard systemName="SigPAE" />);
+    expect(screen.getByText("20% abaixo da média")).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/ActiveUsersCard.tsx
+++ b/src/components/dashboard/ActiveUsersCard.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import MetricCard from "@/components/dashboard/MetricCard";
+import { useActiveUsers } from "@/hooks/useActiveUsers";
+import type { MetricTrend } from "@/types/metric";
+
+type Props = {
+  readonly systemName?: string;
+  readonly className?: string;
+};
+
+const ptBrFormatter = new Intl.NumberFormat("pt-BR");
+
+function formatCount(value: number) {
+  return ptBrFormatter.format(value);
+}
+
+function buildTrendLabel(trend: MetricTrend, percentage: number) {
+  if (trend === "on-average") return "Na média";
+  const suffix = trend === "above" ? "acima da média" : "abaixo da média";
+  return `${percentage}% ${suffix}`;
+}
+
+export default function ActiveUsersCard({ systemName, className }: Props) {
+  const { data, isLoading, isFetching, isError, refetch } = useActiveUsers({
+    systemName: systemName ?? "",
+  });
+
+  return (
+    <MetricCard
+      title="Usuários ativos"
+      systemName={systemName}
+      isLoading={isLoading || isFetching}
+      isError={isError}
+      onRetry={() => refetch()}
+      errorMessage="Não foi possível carregar os usuários ativos."
+      value={data ? formatCount(data.activeCount) : undefined}
+      trend={data?.trend}
+      trendLabel={data ? buildTrendLabel(data.trend, data.differencePercentage) : undefined}
+      comparison={data ? `média: ${formatCount(data.averageCount)}` : undefined}
+      className={className}
+    />
+  );
+}

--- a/src/components/dashboard/AverageSessionCard.test.tsx
+++ b/src/components/dashboard/AverageSessionCard.test.tsx
@@ -1,0 +1,126 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { AverageSessionResponse } from "@/types/averageSession";
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: (props: Readonly<React.HTMLAttributes<HTMLDivElement>>) => (
+    <div data-testid="skeleton" {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...rest
+  }: Readonly<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+    <button data-testid="retry-button" {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+type MockQueryResult = {
+  data?: AverageSessionResponse;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => void;
+};
+
+let mockQueryResult: MockQueryResult = {
+  data: undefined,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+
+vi.mock("@/hooks/useAverageSession", () => ({
+  useAverageSession: () => mockQueryResult,
+}));
+
+import AverageSessionCard from "./AverageSessionCard";
+
+describe("<AverageSessionCard />", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryResult = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
+  });
+
+  it("sem systemName mostra placeholder", () => {
+    render(<AverageSessionCard />);
+    expect(screen.getByText("Selecione um projeto")).toBeInTheDocument();
+  });
+
+  it("loading mostra skeletons", () => {
+    mockQueryResult = { ...mockQueryResult, isLoading: true };
+    render(<AverageSessionCard systemName="SigPAE" />);
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("erro mostra mensagem e botão de retry", async () => {
+    const refetch = vi.fn();
+    mockQueryResult = { ...mockQueryResult, isError: true, refetch };
+    render(<AverageSessionCard systemName="SigPAE" />);
+
+    expect(
+      screen.getByText("Não foi possível carregar a média de sessão.")
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("retry-button"));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renderiza valor formatado e badge 'Na média' quando trend = on-average", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        currentSeconds: 872,
+        averageSeconds: 868,
+        trend: "on-average",
+      },
+    };
+    render(<AverageSessionCard systemName="SigPAE" />);
+
+    expect(screen.getByText("14m 32s")).toBeInTheDocument();
+    expect(screen.getByText("Na média")).toBeInTheDocument();
+    expect(screen.getByText(/média: 14m 28s/)).toBeInTheDocument();
+  });
+
+  it("renderiza badge 'Acima da média' quando trend = above", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        currentSeconds: 1000,
+        averageSeconds: 800,
+        trend: "above",
+      },
+    };
+    render(<AverageSessionCard systemName="SigPAE" />);
+    expect(screen.getByText("Acima da média")).toBeInTheDocument();
+  });
+
+  it("renderiza badge 'Abaixo da média' quando trend = below", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        currentSeconds: 500,
+        averageSeconds: 800,
+        trend: "below",
+      },
+    };
+    render(<AverageSessionCard systemName="SigPAE" />);
+    expect(screen.getByText("Abaixo da média")).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/AverageSessionCard.tsx
+++ b/src/components/dashboard/AverageSessionCard.tsx
@@ -1,16 +1,18 @@
 "use client";
 
-import { ArrowRight, ArrowUp, ArrowDown, RotateCcw } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import MetricCard from "@/components/dashboard/MetricCard";
 import { useAverageSession } from "@/hooks/useAverageSession";
-import type { AverageSessionTrend } from "@/types/averageSession";
+import type { MetricTrend } from "@/types/metric";
 
 type Props = {
   readonly systemName?: string;
   readonly className?: string;
+};
+
+const TREND_LABEL: Record<MetricTrend, string> = {
+  "on-average": "Na média",
+  above: "Acima da média",
+  below: "Abaixo da média",
 };
 
 function formatDuration(totalSeconds: number) {
@@ -19,104 +21,24 @@ function formatDuration(totalSeconds: number) {
   return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
 }
 
-const TREND_CONFIG: Record<
-  AverageSessionTrend,
-  { label: string; Icon: typeof ArrowRight; className: string }
-> = {
-  "on-average": {
-    label: "Na média",
-    Icon: ArrowRight,
-    className: "bg-[#F3F4F6] text-[#475569]",
-  },
-  above: {
-    label: "Acima da média",
-    Icon: ArrowUp,
-    className: "bg-[#D1FAE5] text-[#065F46]",
-  },
-  below: {
-    label: "Abaixo da média",
-    Icon: ArrowDown,
-    className: "bg-[#FEF3C7] text-[#92400E]",
-  },
-};
-
-function TrendBadge({ trend }: { readonly trend: AverageSessionTrend }) {
-  const { label, Icon, className } = TREND_CONFIG[trend];
-  return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold",
-        className
-      )}
-      aria-label={`Tendência: ${label}`}
-    >
-      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
-      {label}
-    </span>
-  );
-}
-
 export default function AverageSessionCard({ systemName, className }: Props) {
   const { data, isLoading, isFetching, isError, refetch } = useAverageSession({
     systemName: systemName ?? "",
   });
 
-  const content = () => {
-    if (!systemName) {
-      return (
-        <div className="text-sm text-muted-foreground">Selecione um projeto</div>
-      );
-    }
-
-    if (isLoading || isFetching) {
-      return (
-        <div className="space-y-3">
-          <Skeleton className="h-10 w-32" />
-          <Skeleton className="h-6 w-52" />
-        </div>
-      );
-    }
-
-    if (isError || !data) {
-      return (
-        <div>
-          <div className="text-sm text-muted-foreground">
-            Não foi possível carregar a média de sessão.
-          </div>
-          <Button
-            onClick={() => refetch()}
-            variant="secondary"
-            size="sm"
-            className="mt-3"
-          >
-            <RotateCcw className="mr-2 h-4 w-4" />
-            Tentar novamente
-          </Button>
-        </div>
-      );
-    }
-
-    return (
-      <>
-        <div className="text-3xl font-bold text-[#2563EB]">
-          {formatDuration(data.currentSeconds)}
-        </div>
-        <div className="mt-4 flex items-center gap-3">
-          <TrendBadge trend={data.trend} />
-          <span className="text-sm text-muted-foreground">
-            média: {formatDuration(data.averageSeconds)}
-          </span>
-        </div>
-      </>
-    );
-  };
-
   return (
-    <Card className={cn("rounded-md shadow-sm gap-3 py-4 px-1", className)}>
-      <CardHeader className="pb-1 px-4">
-        <CardTitle className="text-base font-bold">Média de sessão</CardTitle>
-      </CardHeader>
-      <CardContent className="px-4">{content()}</CardContent>
-    </Card>
+    <MetricCard
+      title="Média de sessão"
+      systemName={systemName}
+      isLoading={isLoading || isFetching}
+      isError={isError}
+      onRetry={() => refetch()}
+      errorMessage="Não foi possível carregar a média de sessão."
+      value={data ? formatDuration(data.currentSeconds) : undefined}
+      trend={data?.trend}
+      trendLabel={data ? TREND_LABEL[data.trend] : undefined}
+      comparison={data ? `média: ${formatDuration(data.averageSeconds)}` : undefined}
+      className={className}
+    />
   );
 }

--- a/src/components/dashboard/AverageSessionCard.tsx
+++ b/src/components/dashboard/AverageSessionCard.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { ArrowRight, ArrowUp, ArrowDown, RotateCcw } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useAverageSession } from "@/hooks/useAverageSession";
+import type { AverageSessionTrend } from "@/types/averageSession";
+
+type Props = {
+  readonly systemName?: string;
+  readonly className?: string;
+};
+
+function formatDuration(totalSeconds: number) {
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}m ${seconds.toString().padStart(2, "0")}s`;
+}
+
+const TREND_CONFIG: Record<
+  AverageSessionTrend,
+  { label: string; Icon: typeof ArrowRight; className: string }
+> = {
+  "on-average": {
+    label: "Na média",
+    Icon: ArrowRight,
+    className: "bg-[#F3F4F6] text-[#475569]",
+  },
+  above: {
+    label: "Acima da média",
+    Icon: ArrowUp,
+    className: "bg-[#D1FAE5] text-[#065F46]",
+  },
+  below: {
+    label: "Abaixo da média",
+    Icon: ArrowDown,
+    className: "bg-[#FEF3C7] text-[#92400E]",
+  },
+};
+
+function TrendBadge({ trend }: { readonly trend: AverageSessionTrend }) {
+  const { label, Icon, className } = TREND_CONFIG[trend];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold",
+        className
+      )}
+      aria-label={`Tendência: ${label}`}
+    >
+      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}
+
+export default function AverageSessionCard({ systemName, className }: Props) {
+  const { data, isLoading, isFetching, isError, refetch } = useAverageSession({
+    systemName: systemName ?? "",
+  });
+
+  const content = () => {
+    if (!systemName) {
+      return (
+        <div className="text-sm text-muted-foreground">Selecione um projeto</div>
+      );
+    }
+
+    if (isLoading || isFetching) {
+      return (
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-6 w-52" />
+        </div>
+      );
+    }
+
+    if (isError || !data) {
+      return (
+        <div>
+          <div className="text-sm text-muted-foreground">
+            Não foi possível carregar a média de sessão.
+          </div>
+          <Button
+            onClick={() => refetch()}
+            variant="secondary"
+            size="sm"
+            className="mt-3"
+          >
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Tentar novamente
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <div className="text-3xl font-bold text-[#2563EB]">
+          {formatDuration(data.currentSeconds)}
+        </div>
+        <div className="mt-4 flex items-center gap-3">
+          <TrendBadge trend={data.trend} />
+          <span className="text-sm text-muted-foreground">
+            média: {formatDuration(data.averageSeconds)}
+          </span>
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <Card className={cn("rounded-md shadow-sm gap-3 py-4 px-1", className)}>
+      <CardHeader className="pb-1 px-4">
+        <CardTitle className="text-base font-bold">Média de sessão</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4">{content()}</CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/JenkinsJob/index.test.tsx
+++ b/src/components/dashboard/JenkinsJob/index.test.tsx
@@ -11,6 +11,12 @@ function okJson(data: unknown) {
   } as unknown as Response;
 }
 
+function fetchUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
 describe("<JenkinsJob />", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -18,7 +24,7 @@ describe("<JenkinsJob />", () => {
 
   it("com múltiplos subprojetos: mostra select e atualiza automaticamente ao trocar", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
+      const url = fetchUrl(input);
 
       if (url.startsWith("/api/zabbix/jenkins/job?project=PTRF-FrontEnd&env=homolog")) {
         return okJson({
@@ -65,7 +71,6 @@ describe("<JenkinsJob />", () => {
     render(
       withClient(
         <JenkinsJob
-          squad="COPLAN"
           project="SigEscola"
           subprojects={[
             { label: "Backend", key: "PTRF-BackEnd" },
@@ -112,7 +117,7 @@ describe("<JenkinsJob />", () => {
 
   it("com apenas 1 subprojeto: não exige seleção adicional", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
+      const url = fetchUrl(input);
 
       if (url.startsWith("/api/zabbix/jenkins/job?project=SME-NovoSGP")) {
         return okJson({
@@ -132,7 +137,7 @@ describe("<JenkinsJob />", () => {
 
     render(
       withClient(
-        <JenkinsJob squad="COPED" project="Novo SGP" subprojects={[{ label: "SME-NovoSGP", key: "SME-NovoSGP" }]} />
+        <JenkinsJob project="Novo SGP" subprojects={[{ label: "SME-NovoSGP", key: "SME-NovoSGP" }]} />
       )
     );
 
@@ -149,7 +154,7 @@ describe("<JenkinsJob />", () => {
 
   it("projeto N/E (ou sem chaves): não busca releases e mostra mensagem", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
-      const url = String(input);
+      const url = fetchUrl(input);
 
       if (url.startsWith("/api/zabbix/jenkins/job?")) {
         throw new Error("Não deveria chamar endpoint de job");
@@ -158,7 +163,7 @@ describe("<JenkinsJob />", () => {
       throw new Error(`fetch inesperado: ${url}`);
     });
 
-    render(withClient(<JenkinsJob squad="ASCOM" project="Portal Educação" subprojects={[]} />));
+    render(withClient(<JenkinsJob project="Portal Educação" subprojects={[]} />));
 
     expect(
       await screen.findByText("Sem lançamentos disponíveis para este projeto.")

--- a/src/components/dashboard/JenkinsJobCard.test.tsx
+++ b/src/components/dashboard/JenkinsJobCard.test.tsx
@@ -8,7 +8,7 @@ import JenkinsJobCard from "./JenkinsJobCard";
 import type { JenkinsJobSummary } from "@/types/jenkins";
 
 vi.mock("@/components/ui/skeleton", () => {
-  function Skeleton(props: React.HTMLAttributes<HTMLDivElement>) {
+  function Skeleton(props: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
     return <div data-testid="skeleton" {...props} />;
   }
 

--- a/src/components/dashboard/MetricCard/TrendBadge.test.tsx
+++ b/src/components/dashboard/MetricCard/TrendBadge.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TrendBadge } from "./TrendBadge";
+
+describe("<TrendBadge />", () => {
+  it("renderiza label e aria-label", () => {
+    render(<TrendBadge trend="on-average" label="Na média" />);
+    const badge = screen.getByText("Na média");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("aria-label", "Tendência: Na média");
+  });
+
+  it("aplica estilo verde para trend = above", () => {
+    render(<TrendBadge trend="above" label="18% acima da média" />);
+    const badge = screen.getByText("18% acima da média");
+    expect(badge.className).toContain("#D1FAE5");
+    expect(badge.className).toContain("#065F46");
+  });
+
+  it("aplica estilo âmbar para trend = below", () => {
+    render(<TrendBadge trend="below" label="12% abaixo da média" />);
+    const badge = screen.getByText("12% abaixo da média");
+    expect(badge.className).toContain("#FEF3C7");
+    expect(badge.className).toContain("#92400E");
+  });
+
+  it("aplica estilo neutro para trend = on-average", () => {
+    render(<TrendBadge trend="on-average" label="Na média" />);
+    const badge = screen.getByText("Na média");
+    expect(badge.className).toContain("#F3F4F6");
+    expect(badge.className).toContain("#475569");
+  });
+});

--- a/src/components/dashboard/MetricCard/TrendBadge.tsx
+++ b/src/components/dashboard/MetricCard/TrendBadge.tsx
@@ -1,0 +1,42 @@
+import { ArrowDown, ArrowRight, ArrowUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { MetricTrend } from "@/types/metric";
+
+const TREND_CONFIG: Record<
+  MetricTrend,
+  { Icon: typeof ArrowRight; className: string }
+> = {
+  "on-average": {
+    Icon: ArrowRight,
+    className: "bg-[#F3F4F6] text-[#475569]",
+  },
+  above: {
+    Icon: ArrowUp,
+    className: "bg-[#D1FAE5] text-[#065F46]",
+  },
+  below: {
+    Icon: ArrowDown,
+    className: "bg-[#FEF3C7] text-[#92400E]",
+  },
+};
+
+type Props = {
+  readonly trend: MetricTrend;
+  readonly label: string;
+};
+
+export function TrendBadge({ trend, label }: Props) {
+  const { Icon, className } = TREND_CONFIG[trend];
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold",
+        className
+      )}
+      aria-label={`Tendência: ${label}`}
+    >
+      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+      {label}
+    </span>
+  );
+}

--- a/src/components/dashboard/MetricCard/index.test.tsx
+++ b/src/components/dashboard/MetricCard/index.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: (props: Readonly<React.HTMLAttributes<HTMLDivElement>>) => (
+    <div data-testid="skeleton" {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...rest
+  }: Readonly<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+    <button data-testid="retry-button" {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+import MetricCard from "./index";
+
+describe("<MetricCard />", () => {
+  it("sem systemName mostra 'Selecione um projeto'", () => {
+    render(<MetricCard title="Indicador" />);
+    expect(screen.getByText("Indicador")).toBeInTheDocument();
+    expect(screen.getByText("Selecione um projeto")).toBeInTheDocument();
+  });
+
+  it("loading mostra skeletons", () => {
+    render(<MetricCard title="Indicador" systemName="SigPAE" isLoading />);
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("erro mostra mensagem custom e botão de retry", async () => {
+    const onRetry = vi.fn();
+    render(
+      <MetricCard
+        title="Indicador"
+        systemName="SigPAE"
+        isError
+        onRetry={onRetry}
+        errorMessage="Falhou ao carregar."
+      />
+    );
+
+    expect(screen.getByText("Falhou ao carregar.")).toBeInTheDocument();
+    await userEvent.click(screen.getByTestId("retry-button"));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("sucesso renderiza value, trend e comparison", () => {
+    render(
+      <MetricCard
+        title="Indicador"
+        systemName="SigPAE"
+        value="8.398"
+        trend="above"
+        trendLabel="18% acima da média"
+        comparison="média: 7.563"
+      />
+    );
+
+    expect(screen.getByText("8.398")).toBeInTheDocument();
+    expect(screen.getByText("18% acima da média")).toBeInTheDocument();
+    expect(screen.getByText("média: 7.563")).toBeInTheDocument();
+  });
+
+  it("omite TrendBadge quando trend não for informado", () => {
+    render(
+      <MetricCard
+        title="Indicador"
+        systemName="SigPAE"
+        value="8.398"
+        comparison="média: 7.563"
+      />
+    );
+    expect(screen.getByText("8.398")).toBeInTheDocument();
+    expect(screen.queryByLabelText(/Tendência:/)).not.toBeInTheDocument();
+  });
+
+  it("não renderiza botão retry quando onRetry não é passado", () => {
+    render(
+      <MetricCard
+        title="Indicador"
+        systemName="SigPAE"
+        isError
+        errorMessage="Erro"
+      />
+    );
+    expect(screen.getByText("Erro")).toBeInTheDocument();
+    expect(screen.queryByTestId("retry-button")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/MetricCard/index.tsx
+++ b/src/components/dashboard/MetricCard/index.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { RotateCcw } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { TrendBadge } from "./TrendBadge";
+import type { MetricTrend } from "@/types/metric";
+
+type Props = {
+  readonly title: string;
+  readonly systemName?: string;
+  readonly isLoading?: boolean;
+  readonly isError?: boolean;
+  readonly onRetry?: () => void;
+  readonly errorMessage?: string;
+  readonly value?: string;
+  readonly trend?: MetricTrend;
+  readonly trendLabel?: string;
+  readonly comparison?: string;
+  readonly className?: string;
+};
+
+export default function MetricCard({
+  title,
+  systemName,
+  isLoading,
+  isError,
+  onRetry,
+  errorMessage = "Não foi possível carregar os dados.",
+  value,
+  trend,
+  trendLabel,
+  comparison,
+  className,
+}: Props) {
+  const renderContent = () => {
+    if (!systemName) {
+      return <div className="text-sm text-muted-foreground">Selecione um projeto</div>;
+    }
+
+    if (isLoading) {
+      return (
+        <div className="space-y-3">
+          <Skeleton className="h-10 w-32" />
+          <Skeleton className="h-6 w-52" />
+        </div>
+      );
+    }
+
+    if (isError || value === undefined) {
+      return (
+        <div>
+          <div className="text-sm text-muted-foreground">{errorMessage}</div>
+          {onRetry && (
+            <Button
+              onClick={onRetry}
+              variant="secondary"
+              size="sm"
+              className="mt-3"
+            >
+              <RotateCcw className="mr-2 h-4 w-4" />
+              Tentar novamente
+            </Button>
+          )}
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <div className="text-3xl font-bold text-[#2563EB]">{value}</div>
+        <div className="mt-4 flex items-center gap-3">
+          {trend && trendLabel && <TrendBadge trend={trend} label={trendLabel} />}
+          {comparison && (
+            <span className="text-sm text-muted-foreground">{comparison}</span>
+          )}
+        </div>
+      </>
+    );
+  };
+
+  return (
+    <Card className={cn("rounded-md shadow-sm gap-3 py-4 px-1", className)}>
+      <CardHeader className="pb-1 px-4">
+        <CardTitle className="text-base font-bold">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4">{renderContent()}</CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/SelectSistemas/getSistemasPorSquad.test.ts
+++ b/src/components/dashboard/SelectSistemas/getSistemasPorSquad.test.ts
@@ -33,11 +33,18 @@ describe("getSistemasPorSquad", () => {
 
     it("não deve mutar o array original dos squads", () => {
         const sistemas = getSistemasPorSquad("ASCOM");
-        sistemas.push({ id: "99", nome: "Teste" });
+        const novoSistema = {
+            id: "99",
+            nome: "Teste",
+            zabbixQueryFrontend: "",
+            zabbixQueryBackend: "",
+            zabbixQueryFilasRabbitMQ: "",
+            zabbixQueryJenkinsJob: "",
+        };
+        sistemas.push(novoSistema);
 
-        // ✅ Chamada subsequente não deve conter o item mutado
         const sistemasNovos = getSistemasPorSquad("ASCOM");
-        expect(sistemasNovos).not.toContainEqual({ id: "99", nome: "Teste" });
+        expect(sistemasNovos).not.toContainEqual(novoSistema);
     });
 
     it("inclui subprojetos de releases quando existir mapeamento", () => {

--- a/src/components/login/BackgroundForm.test.tsx
+++ b/src/components/login/BackgroundForm.test.tsx
@@ -29,7 +29,7 @@ vi.mock("next/image", () => ({
       typeof src === "object" && src !== null && "src" in src
         ? (src as { src: string }).src
         : src;
-    return <img src={resolvedSrc} alt={props.alt || ""} {...rest} />;
+    return <img src={resolvedSrc} alt={props.alt ?? ""} {...rest} />;
   },
 }));
 

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -29,7 +29,7 @@ export default async function Navbar() {
                                 </Link>
                                 <span className="text-gray-700 text-sm">
                                     Olá,{" "}
-                                    {session.user?.name || session.user?.email}
+                                    {session.user?.name ?? session.user?.email}
                                 </span>
                                 <SignOutButton />
                             </>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -52,7 +52,7 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
-function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+function DialogHeader({ className, ...props }: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
     return (
         <div
             className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)}
@@ -62,7 +62,7 @@ function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivEleme
 }
 DialogHeader.displayName = "DialogHeader";
 
-function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+function DialogFooter({ className, ...props }: Readonly<React.HTMLAttributes<HTMLDivElement>>) {
     return (
         <div
             className={cn(

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -32,8 +32,9 @@ const FormField = <
 >({
     ...props
 }: ControllerProps<TFieldValues, TName>) => {
+    const contextValue = React.useMemo(() => ({ name: props.name }), [props.name]);
     return (
-        <FormFieldContext.Provider value={{ name: props.name }}>
+        <FormFieldContext.Provider value={contextValue}>
             <Controller {...props} />
         </FormFieldContext.Provider>
     );
@@ -75,9 +76,10 @@ const FormItem = React.forwardRef<
     React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
     const id = React.useId();
+    const contextValue = React.useMemo(() => ({ id }), [id]);
 
     return (
-        <FormItemContext.Provider value={{ id }}>
+        <FormItemContext.Provider value={contextValue}>
             <div ref={ref} className={cn("space-y-2", className)} {...props} />
         </FormItemContext.Provider>
     );

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -43,9 +43,7 @@ const InputMask = React.forwardRef<HTMLInputElement, InputMaskProps>(
 )
 InputMask.displayName = 'InputMask'
 
-export type CurrencyInputProps = InputProps
-
-const CurrencyInput = React.forwardRef<HTMLInputElement, CurrencyInputProps>(
+const CurrencyInput = React.forwardRef<HTMLInputElement, InputProps>(
   ({ onChange, ...props }, ref) => {
     return (
       <Input
@@ -63,7 +61,7 @@ const CurrencyInput = React.forwardRef<HTMLInputElement, CurrencyInputProps>(
 )
 CurrencyInput.displayName = 'CurrencyInput'
 
-const DocumentInput = React.forwardRef<HTMLInputElement, CurrencyInputProps>(
+const DocumentInput = React.forwardRef<HTMLInputElement, InputProps>(
   ({ onChange, ...props }, ref) => {
     return (
       <Input
@@ -93,7 +91,7 @@ const DocumentInput = React.forwardRef<HTMLInputElement, CurrencyInputProps>(
 )
 DocumentInput.displayName = 'DocumentInput'
 
-const PhoneInput = React.forwardRef<HTMLInputElement, CurrencyInputProps>(
+const PhoneInput = React.forwardRef<HTMLInputElement, InputProps>(
   ({ onChange, ...props }, ref) => {
     return (
       <Input

--- a/src/components/ui/tabs.test.tsx
+++ b/src/components/ui/tabs.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "./tabs";
+
+function renderTabs(defaultValue = "a") {
+  return render(
+    <Tabs defaultValue={defaultValue}>
+      <TabsList>
+        <TabsTrigger value="a">Tab A</TabsTrigger>
+        <TabsTrigger value="b">Tab B</TabsTrigger>
+      </TabsList>
+      <TabsContent value="a">Conteúdo A</TabsContent>
+      <TabsContent value="b">Conteúdo B</TabsContent>
+    </Tabs>
+  );
+}
+
+describe("<Tabs />", () => {
+  it("renderiza o conteúdo da tab default ativa", () => {
+    renderTabs("a");
+    expect(screen.getByText("Conteúdo A")).toBeInTheDocument();
+    expect(screen.queryByText("Conteúdo B")).not.toBeInTheDocument();
+  });
+
+  it("troca o conteúdo ao clicar em outra tab", async () => {
+    renderTabs("a");
+
+    await userEvent.click(screen.getByRole("tab", { name: "Tab B" }));
+
+    expect(screen.queryByText("Conteúdo A")).not.toBeInTheDocument();
+    expect(screen.getByText("Conteúdo B")).toBeInTheDocument();
+  });
+
+  it("marca aria-selected na tab ativa", async () => {
+    renderTabs("a");
+
+    expect(screen.getByRole("tab", { name: "Tab A" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+    expect(screen.getByRole("tab", { name: "Tab B" })).toHaveAttribute(
+      "aria-selected",
+      "false"
+    );
+
+    await userEvent.click(screen.getByRole("tab", { name: "Tab B" }));
+
+    expect(screen.getByRole("tab", { name: "Tab B" })).toHaveAttribute(
+      "aria-selected",
+      "true"
+    );
+  });
+
+  it("respeita value controlado e dispara onValueChange", async () => {
+    const handleChange = vi.fn();
+
+    function Controlled() {
+      const [value, setValue] = React.useState("a");
+      return (
+        <Tabs
+          defaultValue="a"
+          value={value}
+          onValueChange={(v) => {
+            handleChange(v);
+            setValue(v);
+          }}
+        >
+          <TabsList>
+            <TabsTrigger value="a">A</TabsTrigger>
+            <TabsTrigger value="b">B</TabsTrigger>
+          </TabsList>
+          <TabsContent value="a">A</TabsContent>
+          <TabsContent value="b">B</TabsContent>
+        </Tabs>
+      );
+    }
+
+    render(<Controlled />);
+    await userEvent.click(screen.getByRole("tab", { name: "B" }));
+
+    expect(handleChange).toHaveBeenCalledWith("b");
+  });
+
+  it("lança erro quando trigger é usado fora de Tabs", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(() => render(<TabsTrigger value="x">x</TabsTrigger>)).toThrow(
+      /must be used within <Tabs>/
+    );
+    spy.mockRestore();
+  });
+});

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+type TabsContextValue = {
+  value: string;
+  onValueChange: (value: string) => void;
+};
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+function useTabsContext() {
+  const ctx = React.useContext(TabsContext);
+  if (!ctx) throw new Error("Tabs components must be used within <Tabs>");
+  return ctx;
+}
+
+type TabsProps = {
+  readonly defaultValue: string;
+  readonly value?: string;
+  readonly onValueChange?: (value: string) => void;
+  readonly className?: string;
+  readonly children: React.ReactNode;
+};
+
+function Tabs({
+  defaultValue,
+  value: controlledValue,
+  onValueChange,
+  className,
+  children,
+}: TabsProps) {
+  const [internalValue, setInternalValue] = React.useState(defaultValue);
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled ? controlledValue : internalValue;
+
+  const handleValueChange = React.useCallback(
+    (next: string) => {
+      if (!isControlled) setInternalValue(next);
+      onValueChange?.(next);
+    },
+    [isControlled, onValueChange]
+  );
+
+  const contextValue = React.useMemo(
+    () => ({ value, onValueChange: handleValueChange }),
+    [value, handleValueChange]
+  );
+
+  return (
+    <TabsContext.Provider value={contextValue}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+type TabsListProps = {
+  readonly className?: string;
+  readonly children: React.ReactNode;
+};
+
+function TabsList({ className, children }: TabsListProps) {
+  return (
+    <div
+      role="tablist"
+      className={cn(
+        "flex w-fit items-end gap-10 border-b border-[#E5E7EB] pr-10",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+type TabsTriggerProps = {
+  readonly value: string;
+  readonly className?: string;
+  readonly children: React.ReactNode;
+};
+
+function TabsTrigger({ value, className, children }: TabsTriggerProps) {
+  const { value: activeValue, onValueChange } = useTabsContext();
+  const isActive = activeValue === value;
+
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => onValueChange(value)}
+      className={cn(
+        "relative cursor-pointer pb-3 text-base font-extrabold transition-colors",
+        isActive ? "text-[#0F172A]" : "text-[#94A3B8] hover:text-[#475569]",
+        className
+      )}
+    >
+      {children}
+      {isActive && (
+        <span
+          aria-hidden="true"
+          className="absolute inset-x-0 bottom-0 h-1 rounded-t-md bg-[#2563EB]"
+        />
+      )}
+    </button>
+  );
+}
+
+type TabsContentProps = {
+  readonly value: string;
+  readonly className?: string;
+  readonly children: React.ReactNode;
+};
+
+function TabsContent({ value, className, children }: TabsContentProps) {
+  const { value: activeValue } = useTabsContext();
+  if (activeValue !== value) return null;
+
+  return (
+    <div
+      role="tabpanel"
+      key={value}
+      className={cn(
+        "animate-in fade-in-0 slide-in-from-bottom-1 duration-300",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/src/hooks/useActiveUsers.test.tsx
+++ b/src/hooks/useActiveUsers.test.tsx
@@ -1,0 +1,55 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useActiveUsers } from "./useActiveUsers";
+
+const createWrapper = () => {
+  const Wrapper = ({ children }: { readonly children: React.ReactNode }) => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity },
+      },
+    });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+  Wrapper.displayName = "QueryClientTestWrapper";
+  return Wrapper;
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useActiveUsers", () => {
+  it("não dispara fetch quando systemName é vazio", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useActiveUsers({ systemName: "" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("retorna dados mock e propaga o systemName", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useActiveUsers({ systemName: "Novo SGP" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toMatchObject({
+      system: "Novo SGP",
+      activeCount: expect.any(Number),
+      averageCount: expect.any(Number),
+      differencePercentage: expect.any(Number),
+      trend: expect.stringMatching(/^(on-average|above|below)$/),
+    });
+  });
+});

--- a/src/hooks/useActiveUsers.ts
+++ b/src/hooks/useActiveUsers.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ActiveUsersResponse } from "@/types/activeUsers";
+
+type Options = {
+  systemName: string;
+};
+
+const MOCK_RESPONSE: ActiveUsersResponse = {
+  system: "mock",
+  activeCount: 8398,
+  averageCount: 7563,
+  differencePercentage: 18,
+  trend: "above",
+};
+
+export function useActiveUsers({ systemName }: Options) {
+  return useQuery<ActiveUsersResponse>({
+    queryKey: ["active-users", systemName],
+    enabled: !!systemName,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      return { ...MOCK_RESPONSE, system: systemName };
+    },
+  });
+}

--- a/src/hooks/useAverageSession.test.tsx
+++ b/src/hooks/useAverageSession.test.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useAverageSession } from "./useAverageSession";
+
+const createWrapper = () => {
+  const Wrapper = ({ children }: { readonly children: React.ReactNode }) => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity },
+      },
+    });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+  Wrapper.displayName = "QueryClientTestWrapper";
+  return Wrapper;
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useAverageSession", () => {
+  it("não dispara fetch quando systemName é vazio", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useAverageSession({ systemName: "" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("retorna dados mock e propaga o systemName", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useAverageSession({ systemName: "Novo SGP" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toMatchObject({
+      system: "Novo SGP",
+      currentSeconds: expect.any(Number),
+      averageSeconds: expect.any(Number),
+      trend: expect.stringMatching(/^(on-average|above|below)$/),
+    });
+  });
+});

--- a/src/hooks/useAverageSession.ts
+++ b/src/hooks/useAverageSession.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import type { AverageSessionResponse } from "@/types/averageSession";
+
+type Options = {
+  systemName: string;
+};
+
+const MOCK_RESPONSE: AverageSessionResponse = {
+  system: "mock",
+  currentSeconds: 872,
+  averageSeconds: 868,
+  trend: "on-average",
+};
+
+export function useAverageSession({ systemName }: Options) {
+  return useQuery<AverageSessionResponse>({
+    queryKey: ["average-session", systemName],
+    enabled: !!systemName,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      return { ...MOCK_RESPONSE, system: systemName };
+    },
+  });
+}

--- a/src/lib/auth/__tests__/auth.test-utils.ts
+++ b/src/lib/auth/__tests__/auth.test-utils.ts
@@ -101,9 +101,9 @@ export const mockAuthorize = async (
   return {
     id: loginResponse.login,
     name: loginResponse.nome,
-    email: loginResponse.email || "",
+    email: loginResponse.email ?? "",
     rf: loginResponse.login,
-    cpf: loginResponse.cpf || "",
+    cpf: loginResponse.cpf ?? "",
     situacaoUsuario: loginResponse.situacaoUsuario!,
     situacaoGrupo: loginResponse.situacaoGrupo!,
     visoes: loginResponse.visoes || [],

--- a/src/types/activeUsers.ts
+++ b/src/types/activeUsers.ts
@@ -1,0 +1,9 @@
+import type { MetricTrend } from "./metric";
+
+export type ActiveUsersResponse = {
+  system: string;
+  activeCount: number;
+  averageCount: number;
+  differencePercentage: number;
+  trend: MetricTrend;
+};

--- a/src/types/averageSession.ts
+++ b/src/types/averageSession.ts
@@ -1,0 +1,8 @@
+export type AverageSessionTrend = "above" | "below" | "on-average";
+
+export type AverageSessionResponse = {
+  system: string;
+  currentSeconds: number;
+  averageSeconds: number;
+  trend: AverageSessionTrend;
+};

--- a/src/types/averageSession.ts
+++ b/src/types/averageSession.ts
@@ -1,8 +1,8 @@
-export type AverageSessionTrend = "above" | "below" | "on-average";
+import type { MetricTrend } from "./metric";
 
 export type AverageSessionResponse = {
   system: string;
   currentSeconds: number;
   averageSeconds: number;
-  trend: AverageSessionTrend;
+  trend: MetricTrend;
 };

--- a/src/types/metric.ts
+++ b/src/types/metric.ts
@@ -1,0 +1,1 @@
+export type MetricTrend = "above" | "below" | "on-average";

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,8 +15,11 @@ export default defineConfig({
       'src/**/*.test.tsx',
     ],
     coverage: {
+      provider: 'v8',
       reporter: ['text', 'lcov'],
       reportsDirectory: './coverage',
+      all: true,
+      include: ['src/**/*.{ts,tsx}'],
       exclude: [
         '**/.next/**', // 👈 Exclui TUDO dentro de .next/
         'src/components/ui/**', // 👈 Exclui apenas a pasta 'ui' dentro de components


### PR DESCRIPTION
## Resumo

- Adiciona card **Usuários ativos** na aba Analytics (mock via TanStack Query, pronto para integração).
- Extrai `MetricCard` e `TrendBadge` compartilhados; `AverageSessionCard` refatorado para consumi-los.

> Depende da #105 (aba Analytics). Até o merge, o diff inclui também as mudanças da PR anterior.

## Qualidade

- Quality Gate SonarQube: **OK** — coverage 93,6%, 0 code smells, 0 duplicação.
- 479 testes passando (18 novos).

## Como testar

- [ ] Aba Analytics mostra o card \`8.398\` + badge verde \`↑ 18% acima da média\` + \`média: 7.563\`.
- [ ] Card de Média de sessão segue funcionando após a refatoração.