### PR TITLE
feat(dashboard): adiciona indicador de usuários por página

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.typescript.lcov.reportPaths=coverage/lcov.info
 
 # Excluir arquivos de teste da análise principal
-sonar.exclusions=src/styles/globals.scss,src/**/*.test.ts,src/**/*.test.tsx,src/**/*.spec.ts,src/**/*.spec.tsx,src/**/__tests__/**,src/__mocks__/**,src/setupTests.ts,src/lib/zod-i18n.ts,src/types/**,src/components/ui/**,src/assets/icons/**
+sonar.exclusions=src/styles/globals.scss,src/**/*.test.ts,src/**/*.test.tsx,src/**/*.spec.ts,src/**/*.spec.tsx,src/**/__tests__/**,src/__mocks__/**,src/setupTests.ts,src/lib/zod-i18n.ts,src/types/**,src/components/ui/**,src/assets/icons/**,testes/**
 
 # Arquivos excluídos da análise de cobertura (alinhado com vitest.config.ts)
 sonar.coverage.exclusions=\

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import PeakHoursChart from "@/components/dashboard/PeakHoursChart";
 import AverageSessionCard from "@/components/dashboard/AverageSessionCard";
 import ActiveUsersCard from "@/components/dashboard/ActiveUsersCard";
 import DeviceDistributionCard from "@/components/dashboard/DeviceDistributionCard";
+import UsersByPageCard from "@/components/dashboard/UsersByPageCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useDashboardStore from "@/states/dashboard";
 
@@ -150,6 +151,7 @@ export default function Dashboard() {
                         <AverageSessionCard systemName={projectName} />
                     </div>
                     <div className="grid grid-cols-4 gap-4 mb-4">
+                        <UsersByPageCard systemName={projectName} className="col-span-2" />
                         <DeviceDistributionCard systemName={projectName} className="col-span-2" />
                     </div>
                     <FullWidthSection

--- a/src/components/dashboard/UsersByPageCard.test.tsx
+++ b/src/components/dashboard/UsersByPageCard.test.tsx
@@ -1,0 +1,238 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UsersByPageResponse } from "@/types/usersByPage";
+
+vi.mock("@/components/ui/skeleton", () => ({
+  Skeleton: (props: Readonly<React.HTMLAttributes<HTMLDivElement>>) => (
+    <div data-testid="skeleton" {...props} />
+  ),
+}));
+
+vi.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    ...rest
+  }: Readonly<React.ButtonHTMLAttributes<HTMLButtonElement>>) => (
+    <button data-testid="retry-button" {...rest}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    children,
+    value,
+    onValueChange,
+  }: Readonly<{
+    children: React.ReactNode;
+    value: string;
+    onValueChange: (value: string) => void;
+  }>) => (
+    <select
+      data-testid="select-native"
+      value={value}
+      onChange={(event) => onValueChange(event.target.value)}
+    >
+      {children}
+    </select>
+  ),
+  SelectTrigger: () => null,
+  SelectValue: () => null,
+  SelectContent: ({ children }: Readonly<{ children: React.ReactNode }>) => (
+    <>{children}</>
+  ),
+  SelectItem: ({
+    value,
+    children,
+  }: Readonly<{ value: string; children: React.ReactNode }>) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+type MockQueryResult = {
+  data?: UsersByPageResponse;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => void;
+};
+
+let mockQueryResult: MockQueryResult = {
+  data: undefined,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+
+vi.mock("@/hooks/useUsersByPage", () => ({
+  useUsersByPage: () => mockQueryResult,
+}));
+
+import UsersByPageCard from "./UsersByPageCard";
+
+const buildPages = (count: number): UsersByPageResponse["pages"] =>
+  Array.from({ length: count }, (_, idx) => ({
+    path: `/pagina-${idx + 1}`,
+    currentUsers: 1000 - idx * 10,
+    averageUsers: 2000 - idx * 10,
+  }));
+
+describe("<UsersByPageCard />", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryResult = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn(),
+    };
+  });
+
+  it("sem systemName mostra placeholder", () => {
+    render(<UsersByPageCard />);
+    expect(screen.getByText("Selecione um projeto")).toBeInTheDocument();
+  });
+
+  it("loading mostra skeletons", () => {
+    mockQueryResult = { ...mockQueryResult, isLoading: true };
+    render(<UsersByPageCard systemName="SigPAE" />);
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("erro mostra mensagem e botão de retry", async () => {
+    const refetch = vi.fn();
+    mockQueryResult = { ...mockQueryResult, isError: true, refetch };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    expect(
+      screen.getByText("Não foi possível carregar os usuários por página.")
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId("retry-button"));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("renderiza apenas as 5 primeiras páginas por padrão", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: { system: "SigPAE", pages: buildPages(8) },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    expect(screen.getByTestId("users-by-page-row-1")).toHaveTextContent(
+      "/pagina-1"
+    );
+    expect(screen.getByTestId("users-by-page-row-5")).toHaveTextContent(
+      "/pagina-5"
+    );
+    expect(screen.queryByTestId("users-by-page-row-6")).not.toBeInTheDocument();
+  });
+
+  it("expande e colapsa a lista ao clicar em 'Ver mais páginas'", async () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: { system: "SigPAE", pages: buildPages(8) },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    const expandButton = screen.getByRole("button", { name: /ver mais páginas/i });
+    await userEvent.click(expandButton);
+
+    expect(screen.getByTestId("users-by-page-row-8")).toHaveTextContent(
+      "/pagina-8"
+    );
+
+    const collapseButton = screen.getByRole("button", {
+      name: /ver menos páginas/i,
+    });
+    await userEvent.click(collapseButton);
+
+    expect(screen.queryByTestId("users-by-page-row-6")).not.toBeInTheDocument();
+  });
+
+  it("não exibe botão de expandir quando há 5 ou menos páginas", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: { system: "SigPAE", pages: buildPages(3) },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    expect(
+      screen.queryByRole("button", { name: /ver mais páginas/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("filtra a lista pela página selecionada", async () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: { system: "SigPAE", pages: buildPages(4) },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    const select = screen.getByTestId("select-native");
+    await userEvent.selectOptions(select, "/pagina-2");
+
+    expect(screen.getByTestId("users-by-page-row-1")).toHaveTextContent(
+      "/pagina-2"
+    );
+    expect(screen.queryByTestId("users-by-page-row-2")).not.toBeInTheDocument();
+  });
+
+  it("formata valores numéricos em pt-BR", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        pages: [
+          { path: "/dashboard", currentUsers: 7672, averageUsers: 9565 },
+        ],
+      },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    expect(screen.getByText("7.672")).toBeInTheDocument();
+    expect(screen.getByText("9.565")).toBeInTheDocument();
+  });
+
+  it("barra de acesso é proporcional ao maior valor atual", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        pages: [
+          { path: "/a", currentUsers: 1000, averageUsers: 1000 },
+          { path: "/b", currentUsers: 500, averageUsers: 1000 },
+        ],
+      },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    expect(screen.getByTestId("users-by-page-bar-fill-1")).toHaveStyle({
+      width: "100%",
+    });
+    expect(screen.getByTestId("users-by-page-bar-fill-2")).toHaveStyle({
+      width: "50%",
+    });
+  });
+
+  it("renderiza cabeçalho da tabela com colunas corretas", () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: { system: "SigPAE", pages: buildPages(2) },
+    };
+    const { container } = render(<UsersByPageCard systemName="SigPAE" />);
+
+    const header = container.querySelector(".border-b");
+    expect(header).not.toBeNull();
+    const scope = within(header as HTMLElement);
+    expect(scope.getByText("Descrição")).toBeInTheDocument();
+    expect(scope.getByText("Acesso")).toBeInTheDocument();
+    expect(scope.getByText("Agora")).toBeInTheDocument();
+    expect(scope.getByText("Média")).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard/UsersByPageCard.tsx
+++ b/src/components/dashboard/UsersByPageCard.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ChevronDown, RotateCcw } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { useUsersByPage } from "@/hooks/useUsersByPage";
+import type { UsersByPageEntry } from "@/types/usersByPage";
+
+type Props = {
+  readonly systemName?: string;
+  readonly className?: string;
+};
+
+const ALL_PAGES_VALUE = "all";
+const INITIAL_VISIBLE_ROWS = 5;
+const BAR_COLOR = "#1F3D73";
+
+const ptBrFormatter = new Intl.NumberFormat("pt-BR");
+
+function formatCount(value: number) {
+  return ptBrFormatter.format(value);
+}
+
+type PageRowProps = {
+  readonly index: number;
+  readonly entry: UsersByPageEntry;
+  readonly maxCurrent: number;
+};
+
+function PageRow({ index, entry, maxCurrent }: PageRowProps) {
+  const fillPercentage =
+    maxCurrent > 0
+      ? Math.max(0, Math.min(100, (entry.currentUsers / maxCurrent) * 100))
+      : 0;
+
+  return (
+    <div
+      data-testid={`users-by-page-row-${index}`}
+      className="grid grid-cols-[24px_1fr_120px_96px_96px] items-center gap-4 py-3 text-sm"
+    >
+      <span className="text-[#111827]">{index}</span>
+      <span className="truncate">{entry.path}</span>
+      <div
+        className="h-2 overflow-hidden rounded-full bg-[#E5E7EB]"
+        aria-label={`Acesso: ${Math.round(fillPercentage)}%`}
+      >
+        <div
+          data-testid={`users-by-page-bar-fill-${index}`}
+          className="h-full rounded-full"
+          style={{ width: `${fillPercentage}%`, backgroundColor: BAR_COLOR }}
+        />
+      </div>
+      <span className="font-semibold">{formatCount(entry.currentUsers)}</span>
+      <span className="text-muted-foreground">
+        {formatCount(entry.averageUsers)}
+      </span>
+    </div>
+  );
+}
+
+function TableHeader() {
+  return (
+    <div className="grid grid-cols-[24px_1fr_120px_96px_96px] items-center gap-4 border-b pb-2 text-sm text-[#111827]">
+      <span />
+      <span>Descrição</span>
+      <span>Acesso</span>
+      <span>Agora</span>
+      <span>Média</span>
+    </div>
+  );
+}
+
+export default function UsersByPageCard({ systemName, className }: Props) {
+  const { data, isLoading, isFetching, isError, refetch } = useUsersByPage({
+    systemName: systemName ?? "",
+  });
+
+  const [selectedPath, setSelectedPath] = useState<string>(ALL_PAGES_VALUE);
+  const [expanded, setExpanded] = useState(false);
+
+  const filteredPages = useMemo(() => {
+    if (!data) return [];
+    if (selectedPath === ALL_PAGES_VALUE) return data.pages;
+    return data.pages.filter((entry) => entry.path === selectedPath);
+  }, [data, selectedPath]);
+
+  const visiblePages = expanded
+    ? filteredPages
+    : filteredPages.slice(0, INITIAL_VISIBLE_ROWS);
+
+  const canExpand = filteredPages.length > INITIAL_VISIBLE_ROWS;
+
+  const maxCurrent = useMemo(
+    () =>
+      filteredPages.reduce(
+        (acc, entry) => (entry.currentUsers > acc ? entry.currentUsers : acc),
+        0
+      ),
+    [filteredPages]
+  );
+
+  const content = () => {
+    if (!systemName) {
+      return (
+        <div className="text-sm text-muted-foreground">Selecione um projeto</div>
+      );
+    }
+
+    if (isLoading || isFetching) {
+      return (
+        <div className="space-y-3">
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-full" />
+          <Skeleton className="h-5 w-full" />
+        </div>
+      );
+    }
+
+    if (isError || !data) {
+      return (
+        <div>
+          <div className="text-sm text-muted-foreground">
+            Não foi possível carregar os usuários por página.
+          </div>
+          <Button
+            onClick={() => refetch()}
+            variant="secondary"
+            size="sm"
+            className="mt-3"
+          >
+            <RotateCcw className="mr-2 h-4 w-4" />
+            Tentar novamente
+          </Button>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <TableHeader />
+        <div className="divide-y divide-[#E5E7EB]">
+          {visiblePages.map((entry, idx) => (
+            <PageRow
+              key={entry.path}
+              index={idx + 1}
+              entry={entry}
+              maxCurrent={maxCurrent}
+            />
+          ))}
+        </div>
+        {canExpand && (
+          <div className="flex justify-center border-t pt-3">
+            <button
+              type="button"
+              onClick={() => setExpanded((prev) => !prev)}
+              className="flex items-center gap-2 text-sm font-medium text-[#1F3D73] hover:underline"
+            >
+              <ChevronDown
+                className={cn(
+                  "h-4 w-4 transition-transform",
+                  expanded && "rotate-180"
+                )}
+                aria-hidden="true"
+              />
+              {expanded ? "Ver menos páginas" : "Ver mais páginas"}
+            </button>
+          </div>
+        )}
+      </>
+    );
+  };
+
+  return (
+    <Card className={cn("rounded-md shadow-sm gap-3 py-4 px-1", className)}>
+      <CardHeader className="flex flex-row items-center justify-between gap-4 pb-1 px-4">
+        <CardTitle className="text-base font-bold">Usuários por página</CardTitle>
+        <Select value={selectedPath} onValueChange={setSelectedPath}>
+          <SelectTrigger className="h-9 w-[200px]" aria-label="Filtrar por página">
+            <SelectValue placeholder="Todas as páginas" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_PAGES_VALUE}>Todas as páginas</SelectItem>
+            {data?.pages.map((entry) => (
+              <SelectItem key={entry.path} value={entry.path}>
+                {entry.path}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </CardHeader>
+      <CardContent className="px-4">{content()}</CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useUsersByPage.test.tsx
+++ b/src/hooks/useUsersByPage.test.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useUsersByPage } from "./useUsersByPage";
+
+const createWrapper = () => {
+  const Wrapper = ({ children }: { readonly children: React.ReactNode }) => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: Infinity },
+      },
+    });
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+  Wrapper.displayName = "QueryClientTestWrapper";
+  return Wrapper;
+};
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useUsersByPage", () => {
+  it("não dispara fetch quando systemName é vazio", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useUsersByPage({ systemName: "" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("retorna dados mock e propaga o systemName", async () => {
+    const wrapper = createWrapper();
+
+    const { result } = renderHook(
+      () => useUsersByPage({ systemName: "Novo SGP" }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.system).toBe("Novo SGP");
+    expect(Array.isArray(result.current.data?.pages)).toBe(true);
+    expect(result.current.data?.pages.length).toBeGreaterThan(0);
+    expect(result.current.data?.pages[0]).toMatchObject({
+      path: expect.any(String),
+      currentUsers: expect.any(Number),
+      averageUsers: expect.any(Number),
+    });
+  });
+});

--- a/src/hooks/useUsersByPage.ts
+++ b/src/hooks/useUsersByPage.ts
@@ -1,0 +1,34 @@
+import { useQuery } from "@tanstack/react-query";
+import type { UsersByPageResponse } from "@/types/usersByPage";
+
+type Options = {
+  systemName: string;
+};
+
+const MOCK_PAGES: UsersByPageResponse["pages"] = [
+  { path: "/Sorteios e Plateia", currentUsers: 7672, averageUsers: 7672 },
+  { path: "/Página Inicial", currentUsers: 7062, averageUsers: 7672 },
+  { path: "/Benefícios", currentUsers: 3556, averageUsers: 9565 },
+  { path: "/Descontos, Cortesias e Livros", currentUsers: 2316, averageUsers: 6173 },
+  { path: "/login", currentUsers: 1830, averageUsers: 6140 },
+  { path: "/Meus Agendamentos", currentUsers: 1492, averageUsers: 4890 },
+  { path: "/Eventos Culturais", currentUsers: 1218, averageUsers: 3774 },
+  { path: "/Perfil", currentUsers: 987, averageUsers: 2510 },
+  { path: "/Notificações", currentUsers: 742, averageUsers: 1988 },
+  { path: "/Ajuda", currentUsers: 513, averageUsers: 1305 },
+];
+
+export function useUsersByPage({ systemName }: Options) {
+  return useQuery<UsersByPageResponse>({
+    queryKey: ["users-by-page", systemName],
+    enabled: !!systemName,
+    refetchOnWindowFocus: false,
+    queryFn: async () => {
+      await new Promise((resolve) => setTimeout(resolve, 300));
+      return {
+        system: systemName,
+        pages: MOCK_PAGES,
+      };
+    },
+  });
+}

--- a/src/types/usersByPage.ts
+++ b/src/types/usersByPage.ts
@@ -1,0 +1,10 @@
+export type UsersByPageEntry = {
+  path: string;
+  currentUsers: number;
+  averageUsers: number;
+};
+
+export type UsersByPageResponse = {
+  system: string;
+  pages: UsersByPageEntry[];
+};


### PR DESCRIPTION
## Resumo
- Novo card **Usuários por página** na aba Analytics do dashboard, com filtro por página, barras proporcionais de acesso e expansão/colapso da lista (5 primeiras visíveis por padrão)
- Tipo `UsersByPageResponse` e hook `useUsersByPage` com dados mockados, prontos para integração com backend real
- Exclusão dos artefatos gerados em `testes/**` da análise do SonarQube (evita falso-positivo de acessibilidade em `mail.html` do Allure)

## Arquivos principais
- `src/types/usersByPage.ts`
- `src/hooks/useUsersByPage.ts`
- `src/components/dashboard/UsersByPageCard.tsx`
- `src/app/dashboard/page.tsx` (integração)
- `sonar-project.properties` (exclusão `testes/**`)

## Plano de testes
- [x] Unitários do componente (10 casos): loading, erro/retry, placeholder sem projeto, filtro por página, expansão/colapso, formatação pt-BR, proporção das barras, cabeçalho da tabela
- [x] Unitários do hook (2 casos): fetch desabilitado sem `systemName` e retorno do mock com `systemName` propagado
- [x] `yarn tsc --noEmit` — sem erros
- [x] `yarn lint` — sem warnings
- [x] SonarQube — análise enviada e processada com sucesso após exclusão dos artefatos de teste
- [ ] Validação visual no dashboard (aba Analytics) em ambiente local