### PR TITLE
feat(dashboard): adiciona ordenação de colunas no card de usuários por página

### DIFF
--- a/src/components/dashboard/UsersByPageCard.test.tsx
+++ b/src/components/dashboard/UsersByPageCard.test.tsx
@@ -235,4 +235,93 @@ describe("<UsersByPageCard />", () => {
     expect(scope.getByText("Agora")).toBeInTheDocument();
     expect(scope.getByText("Média")).toBeInTheDocument();
   });
+
+  it("ordena por 'Agora' em ordem ascendente no primeiro clique", async () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        pages: [
+          { path: "/a", currentUsers: 300, averageUsers: 100 },
+          { path: "/b", currentUsers: 100, averageUsers: 200 },
+          { path: "/c", currentUsers: 200, averageUsers: 300 },
+        ],
+      },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    await userEvent.click(screen.getByTestId("users-by-page-sort-currentUsers"));
+
+    expect(screen.getByTestId("users-by-page-row-1")).toHaveTextContent("/b");
+    expect(screen.getByTestId("users-by-page-row-2")).toHaveTextContent("/c");
+    expect(screen.getByTestId("users-by-page-row-3")).toHaveTextContent("/a");
+  });
+
+  it("alterna para descendente no segundo clique e limpa no terceiro", async () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        pages: [
+          { path: "/a", currentUsers: 300, averageUsers: 100 },
+          { path: "/b", currentUsers: 100, averageUsers: 200 },
+          { path: "/c", currentUsers: 200, averageUsers: 300 },
+        ],
+      },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    const trigger = screen.getByTestId("users-by-page-sort-currentUsers");
+
+    await userEvent.click(trigger);
+    await userEvent.click(trigger);
+    expect(screen.getByTestId("users-by-page-row-1")).toHaveTextContent("/a");
+    expect(screen.getByTestId("users-by-page-row-3")).toHaveTextContent("/b");
+
+    await userEvent.click(trigger);
+    expect(screen.getByTestId("users-by-page-row-1")).toHaveTextContent("/a");
+    expect(screen.getByTestId("users-by-page-row-2")).toHaveTextContent("/b");
+    expect(screen.getByTestId("users-by-page-row-3")).toHaveTextContent("/c");
+  });
+
+  it("reseta direção ao trocar de coluna", async () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        pages: [
+          { path: "/z", currentUsers: 100, averageUsers: 300 },
+          { path: "/a", currentUsers: 200, averageUsers: 100 },
+          { path: "/m", currentUsers: 300, averageUsers: 200 },
+        ],
+      },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    await userEvent.click(screen.getByTestId("users-by-page-sort-currentUsers"));
+    await userEvent.click(screen.getByTestId("users-by-page-sort-currentUsers"));
+    await userEvent.click(screen.getByTestId("users-by-page-sort-path"));
+
+    expect(screen.getByTestId("users-by-page-row-1")).toHaveTextContent("/a");
+    expect(screen.getByTestId("users-by-page-row-2")).toHaveTextContent("/m");
+    expect(screen.getByTestId("users-by-page-row-3")).toHaveTextContent("/z");
+  });
+
+  it("indica coluna ativa via aria-sort", async () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: { system: "SigPAE", pages: buildPages(3) },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    const trigger = screen.getByTestId("users-by-page-sort-averageUsers");
+    const columnHeader = trigger.closest('[role="columnheader"]');
+    expect(columnHeader).toHaveAttribute("aria-sort", "none");
+
+    await userEvent.click(trigger);
+    expect(columnHeader).toHaveAttribute("aria-sort", "ascending");
+
+    await userEvent.click(trigger);
+    expect(columnHeader).toHaveAttribute("aria-sort", "descending");
+  });
 });

--- a/src/components/dashboard/UsersByPageCard.test.tsx
+++ b/src/components/dashboard/UsersByPageCard.test.tsx
@@ -315,7 +315,7 @@ describe("<UsersByPageCard />", () => {
     render(<UsersByPageCard systemName="SigPAE" />);
 
     const trigger = screen.getByTestId("users-by-page-sort-averageUsers");
-    const columnHeader = trigger.closest('[role="columnheader"]');
+    const columnHeader = trigger.closest("th");
     expect(columnHeader).toHaveAttribute("aria-sort", "none");
 
     await userEvent.click(trigger);

--- a/src/components/dashboard/UsersByPageCard.tsx
+++ b/src/components/dashboard/UsersByPageCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ChevronDown, RotateCcw } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, ChevronDown, RotateCcw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,10 @@ type Props = {
   readonly className?: string;
 };
 
+type SortKey = "path" | "currentUsers" | "averageUsers";
+type SortDirection = "asc" | "desc";
+type SortState = { key: SortKey; direction: SortDirection } | null;
+
 const ALL_PAGES_VALUE = "all";
 const INITIAL_VISIBLE_ROWS = 5;
 const BAR_COLOR = "#1F3D73";
@@ -29,6 +33,21 @@ const ptBrFormatter = new Intl.NumberFormat("pt-BR");
 
 function formatCount(value: number) {
   return ptBrFormatter.format(value);
+}
+
+function compareEntries(
+  a: UsersByPageEntry,
+  b: UsersByPageEntry,
+  key: SortKey
+): number {
+  if (key === "path") return a.path.localeCompare(b.path, "pt-BR");
+  return a[key] - b[key];
+}
+
+function toggleSort(current: SortState, key: SortKey): SortState {
+  if (!current || current.key !== key) return { key, direction: "asc" };
+  if (current.direction === "asc") return { key, direction: "desc" };
+  return null;
 }
 
 type PageRowProps = {
@@ -68,14 +87,65 @@ function PageRow({ index, entry, maxCurrent }: PageRowProps) {
   );
 }
 
-function TableHeader() {
+type SortableHeaderProps = {
+  readonly label: string;
+  readonly sortKey: SortKey;
+  readonly sort: SortState;
+  readonly onSort: (key: SortKey) => void;
+};
+
+function SortableHeader({ label, sortKey, sort, onSort }: SortableHeaderProps) {
+  const isActive = sort?.key === sortKey;
+  const direction = isActive ? sort.direction : null;
+
+  const Icon = direction === "asc" ? ArrowUp : direction === "desc" ? ArrowDown : ArrowUpDown;
+  const ariaSort =
+    direction === "asc" ? "ascending" : direction === "desc" ? "descending" : "none";
+
+  return (
+    <div role="columnheader" aria-sort={ariaSort}>
+      <button
+        type="button"
+        data-testid={`users-by-page-sort-${sortKey}`}
+        onClick={() => onSort(sortKey)}
+        className={cn(
+          "flex items-center gap-1 text-left transition-colors hover:text-[#1F3D73]",
+          isActive && "font-semibold"
+        )}
+      >
+        <span>{label}</span>
+        <Icon
+          className={cn("h-3.5 w-3.5", !isActive && "opacity-40")}
+          aria-hidden="true"
+        />
+      </button>
+    </div>
+  );
+}
+
+type TableHeaderProps = {
+  readonly sort: SortState;
+  readonly onSort: (key: SortKey) => void;
+};
+
+function TableHeader({ sort, onSort }: TableHeaderProps) {
   return (
     <div className="grid grid-cols-[24px_1fr_120px_96px_96px] items-center gap-4 border-b pb-2 text-sm text-[#111827]">
       <span />
-      <span>Descrição</span>
+      <SortableHeader label="Descrição" sortKey="path" sort={sort} onSort={onSort} />
       <span>Acesso</span>
-      <span>Agora</span>
-      <span>Média</span>
+      <SortableHeader
+        label="Agora"
+        sortKey="currentUsers"
+        sort={sort}
+        onSort={onSort}
+      />
+      <SortableHeader
+        label="Média"
+        sortKey="averageUsers"
+        sort={sort}
+        onSort={onSort}
+      />
     </div>
   );
 }
@@ -87,6 +157,7 @@ export default function UsersByPageCard({ systemName, className }: Props) {
 
   const [selectedPath, setSelectedPath] = useState<string>(ALL_PAGES_VALUE);
   const [expanded, setExpanded] = useState(false);
+  const [sort, setSort] = useState<SortState>(null);
 
   const filteredPages = useMemo(() => {
     if (!data) return [];
@@ -94,20 +165,34 @@ export default function UsersByPageCard({ systemName, className }: Props) {
     return data.pages.filter((entry) => entry.path === selectedPath);
   }, [data, selectedPath]);
 
-  const visiblePages = expanded
-    ? filteredPages
-    : filteredPages.slice(0, INITIAL_VISIBLE_ROWS);
+  const sortedPages = useMemo(() => {
+    if (!sort) return filteredPages;
+    const copy = [...filteredPages];
+    copy.sort((a, b) => {
+      const result = compareEntries(a, b, sort.key);
+      return sort.direction === "asc" ? result : -result;
+    });
+    return copy;
+  }, [filteredPages, sort]);
 
-  const canExpand = filteredPages.length > INITIAL_VISIBLE_ROWS;
+  const visiblePages = expanded
+    ? sortedPages
+    : sortedPages.slice(0, INITIAL_VISIBLE_ROWS);
+
+  const canExpand = sortedPages.length > INITIAL_VISIBLE_ROWS;
 
   const maxCurrent = useMemo(
     () =>
-      filteredPages.reduce(
+      sortedPages.reduce(
         (acc, entry) => (entry.currentUsers > acc ? entry.currentUsers : acc),
         0
       ),
-    [filteredPages]
+    [sortedPages]
   );
+
+  const handleSort = (key: SortKey) => {
+    setSort((current) => toggleSort(current, key));
+  };
 
   const content = () => {
     if (!systemName) {
@@ -149,7 +234,7 @@ export default function UsersByPageCard({ systemName, className }: Props) {
 
     return (
       <>
-        <TableHeader />
+        <TableHeader sort={sort} onSort={handleSort} />
         <div className="divide-y divide-[#E5E7EB]">
           {visiblePages.map((entry, idx) => (
             <PageRow

--- a/src/components/dashboard/UsersByPageCard.tsx
+++ b/src/components/dashboard/UsersByPageCard.tsx
@@ -23,6 +23,7 @@ type Props = {
 
 type SortKey = "path" | "currentUsers" | "averageUsers";
 type SortDirection = "asc" | "desc";
+type AriaSort = "ascending" | "descending" | "none";
 type SortState = { key: SortKey; direction: SortDirection } | null;
 
 const ALL_PAGES_VALUE = "all";
@@ -50,6 +51,18 @@ function toggleSort(current: SortState, key: SortKey): SortState {
   return null;
 }
 
+function getSortIcon(direction: SortDirection | null) {
+  if (direction === "asc") return ArrowUp;
+  if (direction === "desc") return ArrowDown;
+  return ArrowUpDown;
+}
+
+function getAriaSort(direction: SortDirection | null): AriaSort {
+  if (direction === "asc") return "ascending";
+  if (direction === "desc") return "descending";
+  return "none";
+}
+
 type PageRowProps = {
   readonly index: number;
   readonly entry: UsersByPageEntry;
@@ -63,27 +76,31 @@ function PageRow({ index, entry, maxCurrent }: PageRowProps) {
       : 0;
 
   return (
-    <div
+    <tr
       data-testid={`users-by-page-row-${index}`}
-      className="grid grid-cols-[24px_1fr_120px_96px_96px] items-center gap-4 py-3 text-sm"
+      className="border-b border-[#E5E7EB] text-sm"
     >
-      <span className="text-[#111827]">{index}</span>
-      <span className="truncate">{entry.path}</span>
-      <div
-        className="h-2 overflow-hidden rounded-full bg-[#E5E7EB]"
-        aria-label={`Acesso: ${Math.round(fillPercentage)}%`}
-      >
+      <td className="py-3 pr-4 align-middle text-[#111827]">{index}</td>
+      <td className="py-3 pr-4 align-middle truncate">{entry.path}</td>
+      <td className="py-3 pr-4 align-middle">
         <div
-          data-testid={`users-by-page-bar-fill-${index}`}
-          className="h-full rounded-full"
-          style={{ width: `${fillPercentage}%`, backgroundColor: BAR_COLOR }}
-        />
-      </div>
-      <span className="font-semibold">{formatCount(entry.currentUsers)}</span>
-      <span className="text-muted-foreground">
+          className="h-2 overflow-hidden rounded-full bg-[#E5E7EB]"
+          aria-label={`Acesso: ${Math.round(fillPercentage)}%`}
+        >
+          <div
+            data-testid={`users-by-page-bar-fill-${index}`}
+            className="h-full rounded-full"
+            style={{ width: `${fillPercentage}%`, backgroundColor: BAR_COLOR }}
+          />
+        </div>
+      </td>
+      <td className="py-3 pr-4 align-middle font-semibold">
+        {formatCount(entry.currentUsers)}
+      </td>
+      <td className="py-3 align-middle text-muted-foreground">
         {formatCount(entry.averageUsers)}
-      </span>
-    </div>
+      </td>
+    </tr>
   );
 }
 
@@ -92,18 +109,26 @@ type SortableHeaderProps = {
   readonly sortKey: SortKey;
   readonly sort: SortState;
   readonly onSort: (key: SortKey) => void;
+  readonly width: string;
 };
 
-function SortableHeader({ label, sortKey, sort, onSort }: SortableHeaderProps) {
+function SortableHeader({
+  label,
+  sortKey,
+  sort,
+  onSort,
+  width,
+}: SortableHeaderProps) {
   const isActive = sort?.key === sortKey;
   const direction = isActive ? sort.direction : null;
-
-  const Icon = direction === "asc" ? ArrowUp : direction === "desc" ? ArrowDown : ArrowUpDown;
-  const ariaSort =
-    direction === "asc" ? "ascending" : direction === "desc" ? "descending" : "none";
+  const Icon = getSortIcon(direction);
 
   return (
-    <div role="columnheader" aria-sort={ariaSort}>
+    <th
+      scope="col"
+      aria-sort={getAriaSort(direction)}
+      className={cn("pb-2 pr-4 text-left", width)}
+    >
       <button
         type="button"
         data-testid={`users-by-page-sort-${sortKey}`}
@@ -119,7 +144,7 @@ function SortableHeader({ label, sortKey, sort, onSort }: SortableHeaderProps) {
           aria-hidden="true"
         />
       </button>
-    </div>
+    </th>
   );
 }
 
@@ -130,23 +155,35 @@ type TableHeaderProps = {
 
 function TableHeader({ sort, onSort }: TableHeaderProps) {
   return (
-    <div className="grid grid-cols-[24px_1fr_120px_96px_96px] items-center gap-4 border-b pb-2 text-sm text-[#111827]">
-      <span />
-      <SortableHeader label="Descrição" sortKey="path" sort={sort} onSort={onSort} />
-      <span>Acesso</span>
-      <SortableHeader
-        label="Agora"
-        sortKey="currentUsers"
-        sort={sort}
-        onSort={onSort}
-      />
-      <SortableHeader
-        label="Média"
-        sortKey="averageUsers"
-        sort={sort}
-        onSort={onSort}
-      />
-    </div>
+    <thead>
+      <tr className="border-b text-sm text-[#111827]">
+        <th scope="col" className="w-6 pb-2" />
+        <SortableHeader
+          label="Descrição"
+          sortKey="path"
+          sort={sort}
+          onSort={onSort}
+          width="w-auto"
+        />
+        <th scope="col" className="w-[120px] pb-2 pr-4 text-left">
+          Acesso
+        </th>
+        <SortableHeader
+          label="Agora"
+          sortKey="currentUsers"
+          sort={sort}
+          onSort={onSort}
+          width="w-24"
+        />
+        <SortableHeader
+          label="Média"
+          sortKey="averageUsers"
+          sort={sort}
+          onSort={onSort}
+          width="w-24"
+        />
+      </tr>
+    </thead>
   );
 }
 
@@ -234,17 +271,19 @@ export default function UsersByPageCard({ systemName, className }: Props) {
 
     return (
       <>
-        <TableHeader sort={sort} onSort={handleSort} />
-        <div className="divide-y divide-[#E5E7EB]">
-          {visiblePages.map((entry, idx) => (
-            <PageRow
-              key={entry.path}
-              index={idx + 1}
-              entry={entry}
-              maxCurrent={maxCurrent}
-            />
-          ))}
-        </div>
+        <table className="w-full table-fixed">
+          <TableHeader sort={sort} onSort={handleSort} />
+          <tbody>
+            {visiblePages.map((entry, idx) => (
+              <PageRow
+                key={entry.path}
+                index={idx + 1}
+                entry={entry}
+                maxCurrent={maxCurrent}
+              />
+            ))}
+          </tbody>
+        </table>
         {canExpand && (
           <div className="flex justify-center border-t pt-3">
             <button


### PR DESCRIPTION
## Resumo
- Cabeçalhos **Descrição**, **Agora** e **Média** ficam clicáveis para ordenar a lista do card **Usuários por página**
- Ciclo de ordenação: asc → desc → sem ordenação (volta à ordem original retornada pela API)
- Trocar de coluna reinicia em ordem ascendente
- Indicação visual: ícone por coluna (`ArrowUpDown` neutro, `ArrowUp`/`ArrowDown` ativo) e label em `font-semibold` na coluna ativa
- Acessibilidade: wrapper `role="columnheader"` com `aria-sort` (`none`/`ascending`/`descending`)

## Observação
> Este PR está empilhado sobre #109 (`feat/indicador-usuarios-por-pagina`). Os commits dessa PR aparecem aqui até que ela seja mesclada em `test` — o GitHub recalcula o diff automaticamente após o merge.

## Arquivos principais
- `src/components/dashboard/UsersByPageCard.tsx`
- `src/components/dashboard/UsersByPageCard.test.tsx`

## Plano de testes
- [x] 4 novos testes unitários: ordenação ascendente, ciclo asc→desc→limpar, reset ao trocar de coluna, `aria-sort` refletindo estado
- [x] `yarn vitest run` — 504 testes passando
- [x] `yarn tsc --noEmit` — sem erros
- [x] `yarn lint` — sem warnings
- [ ] Validação visual: clicar nos cabeçalhos e conferir ícones, ordem e a11y