### PR TITLE
feat(dashboard): permite ordenação pela coluna de acesso

### DIFF
--- a/src/components/dashboard/UsersByPageCard.test.tsx
+++ b/src/components/dashboard/UsersByPageCard.test.tsx
@@ -307,6 +307,27 @@ describe("<UsersByPageCard />", () => {
     expect(screen.getByTestId("users-by-page-row-3")).toHaveTextContent("/z");
   });
 
+  it("ordena pela coluna 'Acesso' usando o valor de usuários atuais", async () => {
+    mockQueryResult = {
+      ...mockQueryResult,
+      data: {
+        system: "SigPAE",
+        pages: [
+          { path: "/a", currentUsers: 300, averageUsers: 100 },
+          { path: "/b", currentUsers: 100, averageUsers: 200 },
+          { path: "/c", currentUsers: 200, averageUsers: 300 },
+        ],
+      },
+    };
+    render(<UsersByPageCard systemName="SigPAE" />);
+
+    await userEvent.click(screen.getByTestId("users-by-page-sort-access"));
+
+    expect(screen.getByTestId("users-by-page-row-1")).toHaveTextContent("/b");
+    expect(screen.getByTestId("users-by-page-row-2")).toHaveTextContent("/c");
+    expect(screen.getByTestId("users-by-page-row-3")).toHaveTextContent("/a");
+  });
+
   it("indica coluna ativa via aria-sort", async () => {
     mockQueryResult = {
       ...mockQueryResult,

--- a/src/components/dashboard/UsersByPageCard.tsx
+++ b/src/components/dashboard/UsersByPageCard.tsx
@@ -21,7 +21,7 @@ type Props = {
   readonly className?: string;
 };
 
-type SortKey = "path" | "currentUsers" | "averageUsers";
+type SortKey = "path" | "access" | "currentUsers" | "averageUsers";
 type SortDirection = "asc" | "desc";
 type AriaSort = "ascending" | "descending" | "none";
 type SortState = { key: SortKey; direction: SortDirection } | null;
@@ -42,6 +42,7 @@ function compareEntries(
   key: SortKey
 ): number {
   if (key === "path") return a.path.localeCompare(b.path, "pt-BR");
+  if (key === "access") return a.currentUsers - b.currentUsers;
   return a[key] - b[key];
 }
 
@@ -165,9 +166,13 @@ function TableHeader({ sort, onSort }: TableHeaderProps) {
           onSort={onSort}
           width="w-auto"
         />
-        <th scope="col" className="w-[120px] pb-2 pr-4 text-left">
-          Acesso
-        </th>
+        <SortableHeader
+          label="Acesso"
+          sortKey="access"
+          sort={sort}
+          onSort={onSort}
+          width="w-[120px]"
+        />
         <SortableHeader
           label="Agora"
           sortKey="currentUsers"


### PR DESCRIPTION
## Resumo
- Coluna **Acesso** agora também é ordenável (antes apenas Descrição, Agora e Média)
- Ordenação da coluna Acesso usa o valor de `currentUsers` (mesmo dado da barra)
- Cada coluna mantém seu próprio estado de ordenação independente — clicar em Acesso e depois em Agora reinicia em ascendente em cada uma

## Observação
> PR empilhada sobre #110 → #109. O diff completo contra `test` inclui commits das PRs anteriores até que sejam mescladas.

## Arquivos principais
- `src/components/dashboard/UsersByPageCard.tsx`
- `src/components/dashboard/UsersByPageCard.test.tsx`

## Plano de testes
- [x] Novo teste unitário: ordenação pela coluna Acesso (15 testes no total no componente)
- [x] `yarn vitest run` — suíte passando
- [x] `yarn tsc --noEmit` — sem erros
- [x] `yarn lint` — sem warnings
- [ ] Validação visual: clicar no cabeçalho Acesso e conferir ícones/ordem