### PR TITLE
feat(dashboard): adiciona aba Saúde do deploy com seletor de ambientes

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import ActiveUsersCard from "@/components/dashboard/ActiveUsersCard";
 import DeviceDistributionCard from "@/components/dashboard/DeviceDistributionCard";
 import UsersByPageCard from "@/components/dashboard/UsersByPageCard";
 import PeakUsageTodayCard from "@/components/dashboard/PeakUsageTodayCard";
+import EnvironmentHeader from "@/components/dashboard/DeployHealth/EnvironmentHeader";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useDashboardStore from "@/states/dashboard";
 
@@ -45,11 +46,12 @@ export default function Dashboard() {
     const jenkinsSubprojects = activeProject?.jenkinsSubprojects ?? [];
 
     return (
-        <div className="border-b bg-background px-6 py-4">
+        <div className="bg-background px-6 py-4">
             <Tabs defaultValue="operacional">
                 <TabsList className="mb-6 px-1">
                     <TabsTrigger value="operacional">Operacional</TabsTrigger>
                     <TabsTrigger value="analytics">Analytics</TabsTrigger>
+                    <TabsTrigger value="saude-deploy">Saúde do deploy</TabsTrigger>
                 </TabsList>
 
                 <TabsContent value="operacional">
@@ -167,6 +169,10 @@ export default function Dashboard() {
                     >
                         <PeakHoursChart systemName={projectName} className="p-[2px]" />
                     </FullWidthSection>
+                </TabsContent>
+
+                <TabsContent value="saude-deploy">
+                    <EnvironmentHeader />
                 </TabsContent>
             </Tabs>
         </div>

--- a/src/components/dashboard/DeployHealth/EnvironmentHeader.tsx
+++ b/src/components/dashboard/DeployHealth/EnvironmentHeader.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+import {
+  DEPLOY_ENVIRONMENTS,
+  type DeployEnvironment,
+} from "@/types/deployEnvironment";
+import EnvironmentSwitcher from "./EnvironmentSwitcher";
+
+type Props = {
+  readonly defaultEnvironment?: DeployEnvironment;
+  readonly value?: DeployEnvironment;
+  readonly onChange?: (next: DeployEnvironment) => void;
+  readonly className?: string;
+};
+
+export default function EnvironmentHeader({
+  defaultEnvironment = "producao",
+  value,
+  onChange,
+  className,
+}: Props) {
+  const [internalValue, setInternalValue] = useState<DeployEnvironment>(defaultEnvironment);
+  const selected = value ?? internalValue;
+
+  const current = useMemo(
+    () =>
+      DEPLOY_ENVIRONMENTS.find((env) => env.value === selected) ?? DEPLOY_ENVIRONMENTS[0],
+    [selected],
+  );
+
+  const handleChange = (next: DeployEnvironment) => {
+    if (value === undefined) {
+      setInternalValue(next);
+    }
+    onChange?.(next);
+  };
+
+  return (
+    <div className={cn("flex items-center justify-between px-6 py-4", className)}>
+      <div className="flex items-center gap-3">
+        <span className={cn("h-2.5 w-2.5 rounded-full", current.dotClassName)} aria-hidden />
+        <h3 className="text-base font-bold text-[#111827]">
+          {current.label} - {current.branch}
+        </h3>
+      </div>
+      <EnvironmentSwitcher value={selected} onChange={handleChange} />
+    </div>
+  );
+}

--- a/src/components/dashboard/DeployHealth/EnvironmentSwitcher.tsx
+++ b/src/components/dashboard/DeployHealth/EnvironmentSwitcher.tsx
@@ -1,0 +1,47 @@
+import { cn } from "@/lib/utils";
+import {
+  DEPLOY_ENVIRONMENTS,
+  type DeployEnvironment,
+} from "@/types/deployEnvironment";
+
+type Props = {
+  readonly value: DeployEnvironment;
+  readonly onChange: (next: DeployEnvironment) => void;
+  readonly className?: string;
+};
+
+export default function EnvironmentSwitcher({ value, onChange, className }: Props) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Selecionar ambiente"
+      className={cn(
+        "inline-flex items-stretch overflow-hidden rounded-lg border border-[#1E3A8A] bg-white",
+        className,
+      )}
+    >
+      {DEPLOY_ENVIRONMENTS.map((env, index) => {
+        const isSelected = env.value === value;
+        return (
+          <button
+            key={env.value}
+            type="button"
+            role="radio"
+            aria-checked={isSelected}
+            onClick={() => onChange(env.value)}
+            className={cn(
+              "inline-flex items-center gap-2 px-6 py-2 text-sm font-bold transition-colors",
+              index > 0 && "border-l-2 border-[#1E3A8A]",
+              isSelected
+                ? "bg-[#1E3A8A] text-white"
+                : "bg-white text-[#1E3A8A] hover:bg-gray-50",
+            )}
+          >
+            <span className={cn("h-2.5 w-2.5 rounded-full", env.dotClassName)} aria-hidden />
+            {env.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/dashboard/DeployHealth/EnvironmentSwitcher.tsx
+++ b/src/components/dashboard/DeployHealth/EnvironmentSwitcher.tsx
@@ -8,40 +8,49 @@ type Props = {
   readonly value: DeployEnvironment;
   readonly onChange: (next: DeployEnvironment) => void;
   readonly className?: string;
+  readonly name?: string;
 };
 
-export default function EnvironmentSwitcher({ value, onChange, className }: Props) {
+export default function EnvironmentSwitcher({
+  value,
+  onChange,
+  className,
+  name = "deploy-environment",
+}: Props) {
   return (
-    <div
-      role="radiogroup"
-      aria-label="Selecionar ambiente"
+    <fieldset
       className={cn(
         "inline-flex items-stretch overflow-hidden rounded-lg border border-[#1E3A8A] bg-white",
         className,
       )}
     >
+      <legend className="sr-only">Selecionar ambiente</legend>
       {DEPLOY_ENVIRONMENTS.map((env, index) => {
         const isSelected = env.value === value;
         return (
-          <button
+          <label
             key={env.value}
-            type="button"
-            role="radio"
-            aria-checked={isSelected}
-            onClick={() => onChange(env.value)}
             className={cn(
-              "inline-flex items-center gap-2 px-6 py-2 text-sm font-bold transition-colors",
-              index > 0 && "border-l-2 border-[#1E3A8A]",
+              "inline-flex cursor-pointer items-center gap-2 px-6 py-2 text-sm font-bold transition-colors focus-within:ring-2 focus-within:ring-[#2563EB] focus-within:ring-inset",
+              index > 0 && "border-l border-[#1E3A8A]",
               isSelected
                 ? "bg-[#1E3A8A] text-white"
                 : "bg-white text-[#1E3A8A] hover:bg-gray-50",
             )}
           >
+            <input
+              type="radio"
+              name={name}
+              value={env.value}
+              checked={isSelected}
+              onChange={() => onChange(env.value)}
+              className="sr-only"
+            />
             <span className={cn("h-2.5 w-2.5 rounded-full", env.dotClassName)} aria-hidden />
             {env.label}
-          </button>
+          </label>
         );
       })}
-    </div>
+    </fieldset>
   );
 }

--- a/src/types/deployEnvironment.ts
+++ b/src/types/deployEnvironment.ts
@@ -1,0 +1,14 @@
+export type DeployEnvironment = "producao" | "homologacao" | "qa";
+
+export type DeployEnvironmentInfo = {
+  value: DeployEnvironment;
+  label: string;
+  dotClassName: string;
+  branch: string;
+};
+
+export const DEPLOY_ENVIRONMENTS: ReadonlyArray<DeployEnvironmentInfo> = [
+  { value: "producao", label: "Produção", dotClassName: "bg-red-500", branch: "Master" },
+  { value: "homologacao", label: "Homologação", dotClassName: "bg-amber-400", branch: "Homolog" },
+  { value: "qa", label: "QA", dotClassName: "bg-green-500", branch: "QA" },
+];


### PR DESCRIPTION
## Resumo
- Adiciona nova aba **Saúde do deploy** no dashboard, ao lado de *Analytics*
- Cria seletor de ambientes (Produção, Homologação, QA) reutilizável, com header indicando ambiente e branch atuais

## Arquivos principais
- `src/components/dashboard/DeployHealth/EnvironmentHeader.tsx`
- `src/components/dashboard/DeployHealth/EnvironmentSwitcher.tsx`
- `src/types/deployEnvironment.ts`
- `src/app/dashboard/page.tsx`

## Plano de testes
- [ ] Acessar o dashboard e abrir a nova aba **Saúde do deploy**
- [ ] Alternar entre Produção, Homologação e QA e conferir a atualização do header