### PR TITLE
feat(dashboard): adiciona filtro de período na aba Analytics

### DIFF
--- a/src/actions/jenkins-metrics.test.ts
+++ b/src/actions/jenkins-metrics.test.ts
@@ -43,6 +43,26 @@ describe("jenkins metrics action", () => {
     }
   });
 
+  it("cai no job no root quando candidatos /master e /main retornam 404", async () => {
+    const { getJenkinsBranchBuildMetrics } = await import("./jenkins-metrics");
+    fetchJenkinsJobMock
+      .mockRejectedValueOnce({ response: { status: 404 } })
+      .mockRejectedValueOnce({ response: { status: 404 } })
+      .mockResolvedValueOnce({
+        name: "ROLE-AGROECOLOGICO",
+        url: "https://jenkins.example/job/ROLE-AGROECOLOGICO/",
+        healthReport: [{ score: 90 }],
+        lastBuild: { number: 5, result: "SUCCESS", duration: 1000, timestamp: 1711814400000 },
+      });
+
+    const result = await getJenkinsBranchBuildMetrics("ROLE-AGROECOLOGICO");
+
+    expect(fetchJenkinsJobMock).toHaveBeenNthCalledWith(1, "ROLE-AGROECOLOGICO/master");
+    expect(fetchJenkinsJobMock).toHaveBeenNthCalledWith(2, "ROLE-AGROECOLOGICO/main");
+    expect(fetchJenkinsJobMock).toHaveBeenNthCalledWith(3, "ROLE-AGROECOLOGICO");
+    expect(result.found).toBe(true);
+  });
+
   it("tenta branches de homologação quando ambiente é homolog", async () => {
     const { getJenkinsBranchBuildMetrics } = await import("./jenkins-metrics");
     fetchJenkinsJobMock
@@ -72,7 +92,8 @@ describe("jenkins metrics action", () => {
 
     expect(result).toEqual({
       found: false,
-      message: "Job não encontrado no Jenkins (tentado: SME-NovoSGP/master, SME-NovoSGP/main)",
+      message:
+        "Job não encontrado no Jenkins (tentado: SME-NovoSGP/master, SME-NovoSGP/main, SME-NovoSGP)",
     });
   });
 });

--- a/src/actions/jenkins-metrics.ts
+++ b/src/actions/jenkins-metrics.ts
@@ -9,7 +9,7 @@ import type {
   JenkinsMetricsApiResponse,
 } from "@/types/jenkins-metrics";
 
-type JenkinsEnvironment = "prod" | "homolog";
+import type { JenkinsEnvironment } from "@/types/deployEnvironment";
 
 function normalizeProjectFullName(projectFullName: string): string | null {
   const normalized = projectFullName.trim();
@@ -48,7 +48,25 @@ function buildCandidateFullNames(project: string, environment: JenkinsEnvironmen
     return [...new Set(homologCandidates.map((env) => `${base}/${env}`))];
   }
 
-  return project.includes("/") ? [project] : [`${project}/master`, `${project}/main`];
+  if (environment === "test") {
+    const testCandidates = [
+      ...(currentEnv && /prod/i.test(currentEnv)
+        ? [currentEnv.replaceAll(/prod/gi, "test")]
+        : []),
+      "test",
+      "teste",
+      "testes",
+      "qa",
+      "develop",
+      "dev",
+    ];
+
+    return [...new Set(testCandidates.map((env) => `${base}/${env}`))];
+  }
+
+  return project.includes("/")
+    ? [project]
+    : [`${project}/master`, `${project}/main`, project];
 }
 
 function normalizeStatus(build: JenkinsJobApiBuild | null | undefined): JenkinsBuildStatus {

--- a/src/app/api/jenkins/metrics/route.ts
+++ b/src/app/api/jenkins/metrics/route.ts
@@ -1,9 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { getJenkinsBranchBuildMetrics } from "@/actions/jenkins-metrics";
+import type { JenkinsEnvironment } from "@/types/deployEnvironment";
 
 export const runtime = "nodejs";
 export const revalidate = 0;
+
+function resolveJenkinsEnvironment(env: string): JenkinsEnvironment {
+  if (env === "homolog") return "homolog";
+  if (env === "test") return "test";
+  return "prod";
+}
 
 export async function GET(req: NextRequest) {
   const session = await auth();
@@ -15,8 +22,7 @@ export async function GET(req: NextRequest) {
 
   if (!project) return NextResponse.json({ error: "project é obrigatório" }, { status: 400 });
 
-  const resolvedEnv =
-    env === "homolog" ? "homolog" : env === "test" ? "test" : "prod";
+  const resolvedEnv = resolveJenkinsEnvironment(env);
 
   try {
     const metrics = await getJenkinsBranchBuildMetrics(project, resolvedEnv);

--- a/src/app/api/jenkins/metrics/route.ts
+++ b/src/app/api/jenkins/metrics/route.ts
@@ -15,8 +15,11 @@ export async function GET(req: NextRequest) {
 
   if (!project) return NextResponse.json({ error: "project é obrigatório" }, { status: 400 });
 
+  const resolvedEnv =
+    env === "homolog" ? "homolog" : env === "test" ? "test" : "prod";
+
   try {
-    const metrics = await getJenkinsBranchBuildMetrics(project, env === "homolog" ? "homolog" : "prod");
+    const metrics = await getJenkinsBranchBuildMetrics(project, resolvedEnv);
     return NextResponse.json(metrics);
   } catch (e: unknown) {
     const errorMessage =

--- a/src/app/dashboard/DashboardShell.tsx
+++ b/src/app/dashboard/DashboardShell.tsx
@@ -10,6 +10,7 @@ import {
 import { AppSidebar } from "@/components/dashboard/Sidebar/app-sidebar";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { SelectSistemas } from "@/components/dashboard/SelectSistemas";
+import AnalyticsFilters from "@/components/dashboard/Analytics/AnalyticsFilters";
 import { WelcomeModal } from "@/components/dashboard/Onboarding/WelcomeModal";
 import { TourOverlay } from "@/components/dashboard/Onboarding/TourOverlay";
 import { SessionGuard } from "@/components/dashboard/SessionGuard";
@@ -34,7 +35,7 @@ export function DashboardShell({ children, session }: DashboardShellProps) {
                         <SidebarTrigger className="md:hidden" />
                         <div id="onboarding-header-section">
                             <PageHeader />
-                            <SelectSistemas />
+                            <SelectSistemas rightSlot={<AnalyticsFilters />} />
                         </div>
                         {children}
                     </SidebarInset>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -19,6 +19,10 @@ type StoreState = {
     zabbixQueryJenkinsJob?: string;
     jenkinsSubprojects?: unknown[];
   };
+  activeTab?: string;
+  activePeriod?: string;
+  setActiveTab?: (tab: string) => void;
+  setActivePeriod?: (period: string) => void;
 };
 let mockStoreState: StoreState = {
   activeItem: { title: "COPED" },
@@ -27,6 +31,14 @@ let mockStoreState: StoreState = {
     zabbixQueryFrontend: "Portal SME",
     zabbixQueryBackend: "API SME",
     zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
+  },
+  activeTab: "operacional",
+  activePeriod: "hoje",
+  setActiveTab: (tab) => {
+    mockStoreState = { ...mockStoreState, activeTab: tab };
+  },
+  setActivePeriod: (period) => {
+    mockStoreState = { ...mockStoreState, activePeriod: period };
   },
 };
 
@@ -98,6 +110,14 @@ describe("Dashboard page", () => {
         zabbixQueryBackend: "API SME",
         zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
       },
+      activeTab: "operacional",
+      activePeriod: "hoje",
+      setActiveTab: (tab) => {
+        mockStoreState = { ...mockStoreState, activeTab: tab };
+      },
+      setActivePeriod: (period) => {
+        mockStoreState = { ...mockStoreState, activePeriod: period };
+      },
     };
   });
 
@@ -121,6 +141,7 @@ describe("Dashboard page", () => {
 
   test("renderiza Jenkins - Branches e Builds na aba Saúde do deploy à esquerda do Sonar", () => {
     mockStoreState = {
+      ...mockStoreState,
       activeItem: { title: "COPED" },
       activeProject: {
         nome: "Novo SGP",
@@ -144,7 +165,7 @@ describe("Dashboard page", () => {
   });
 
   test("quando não há projeto ativo, passa strings vazias para os filhos (ramo do ??)", () => {
-    mockStoreState = { activeProject: null };
+    mockStoreState = { ...mockStoreState, activeProject: null };
 
     render(withClient(<Dashboard />));
 
@@ -156,6 +177,7 @@ describe("Dashboard page", () => {
 
   test("trima os nomes antes de passar (ramo do ?.trim())", () => {
     mockStoreState = {
+      ...mockStoreState,
       activeItem: { title: "COPED" },
       activeProject: {
         nome: "   Novo SGP   ",
@@ -174,6 +196,7 @@ describe("Dashboard page", () => {
 
   test("quando um campo específico está undefined, cai no fallback vazio para aquele filho", () => {
     mockStoreState = {
+      ...mockStoreState,
       activeItem: { title: "COPED" },
       activeProject: {
         nome: "Novo SGP",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -180,7 +180,11 @@ export default function Dashboard() {
                     <EnvironmentHeader value={deployEnvironment} onChange={setDeployEnvironment} />
                     <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-4">
                         <div id="onboarding-lancamentos" className="lg:col-span-1">
-                            <JenkinsJob project={projectName} subprojects={jenkinsSubprojects} />
+                            <JenkinsJob
+                                project={projectName}
+                                subprojects={jenkinsSubprojects}
+                                environment={deployEnvironment}
+                            />
                         </div>
                         <SonarQualityIndicatorsCard
                             projectName={projectName}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -17,6 +17,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import useDashboardStore from "@/states/dashboard";
 import { useState } from "react";
 import type { DeployEnvironment } from "@/types/deployEnvironment";
+import type { DashboardTab } from "@/types/analyticsPeriod";
 
 type FullWidthSectionProps = {
     readonly id?: string;
@@ -42,6 +43,8 @@ function FullWidthSection({ id, title, tooltip, children }: FullWidthSectionProp
 
 export default function Dashboard() {
     const activeProject = useDashboardStore((state) => state.activeProject);
+    const setActiveTab = useDashboardStore((state) => state.setActiveTab);
+    const activePeriod = useDashboardStore((state) => state.activePeriod);
     const projectName = activeProject?.nome?.trim() ?? "";
     const projectNameFrontEnd = activeProject?.zabbixQueryFrontend?.trim() ?? "";
     const projectNameBackEnd = activeProject?.zabbixQueryBackend?.trim() ?? "";
@@ -51,7 +54,10 @@ export default function Dashboard() {
 
     return (
         <div className="bg-background px-6 py-4">
-            <Tabs defaultValue="operacional">
+            <Tabs
+                defaultValue="operacional"
+                onValueChange={(value) => setActiveTab(value as DashboardTab)}
+            >
                 <TabsList className="mb-6 px-1">
                     <TabsTrigger value="operacional">Operacional</TabsTrigger>
                     <TabsTrigger value="analytics">Analytics</TabsTrigger>
@@ -149,13 +155,13 @@ export default function Dashboard() {
 
                 <TabsContent value="analytics">
                     <div className="grid grid-cols-3 gap-4 mb-4">
-                        <ActiveUsersCard systemName={projectName} />
-                        <AverageSessionCard systemName={projectName} />
-                        <PeakUsageTodayCard systemName={projectName} />
+                        <ActiveUsersCard systemName={projectName} period={activePeriod} />
+                        <AverageSessionCard systemName={projectName} period={activePeriod} />
+                        <PeakUsageTodayCard systemName={projectName} period={activePeriod} />
                     </div>
                     <div className="grid grid-cols-4 gap-4 mb-4">
-                        <UsersByPageCard systemName={projectName} className="col-span-2" />
-                        <DeviceDistributionCard systemName={projectName} className="col-span-2" />
+                        <UsersByPageCard systemName={projectName} period={activePeriod} className="col-span-2" />
+                        <DeviceDistributionCard systemName={projectName} period={activePeriod} className="col-span-2" />
                     </div>
                     <FullWidthSection
                         title="Horários de pico"
@@ -166,7 +172,7 @@ export default function Dashboard() {
                             </p>
                         }
                     >
-                        <PeakHoursChart systemName={projectName} className="p-[2px]" />
+                        <PeakHoursChart systemName={projectName} period={activePeriod} className="p-[2px]" />
                     </FullWidthSection>
                 </TabsContent>
 

--- a/src/components/dashboard/ActiveUsersCard.tsx
+++ b/src/components/dashboard/ActiveUsersCard.tsx
@@ -3,9 +3,11 @@
 import MetricCard from "@/components/dashboard/MetricCard";
 import { useActiveUsers } from "@/hooks/useActiveUsers";
 import type { MetricTrend } from "@/types/metric";
+import type { AnalyticsPeriod } from "@/types/analyticsPeriod";
 
 type Props = {
   readonly systemName?: string;
+  readonly period?: AnalyticsPeriod;
   readonly className?: string;
 };
 
@@ -21,9 +23,10 @@ function buildTrendLabel(trend: MetricTrend, percentage: number) {
   return `${percentage}% ${suffix}`;
 }
 
-export default function ActiveUsersCard({ systemName, className }: Props) {
+export default function ActiveUsersCard({ systemName, period, className }: Props) {
   const { data, isLoading, isFetching, isError, refetch } = useActiveUsers({
     systemName: systemName ?? "",
+    period,
   });
 
   return (

--- a/src/components/dashboard/Analytics/AnalyticsAutoRefreshIndicator.tsx
+++ b/src/components/dashboard/Analytics/AnalyticsAutoRefreshIndicator.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { cn } from "@/lib/utils";
 import { ANALYTICS_QUERY_KEYS } from "./analyticsQueryKeys";
 
@@ -19,6 +19,20 @@ function formatCountdown(seconds: number): string {
   return `${minutes}m ${String(remaining).padStart(2, "0")}s`;
 }
 
+function invalidateAnalyticsQueries(queryClient: QueryClient): void {
+  ANALYTICS_QUERY_KEYS.forEach((key) => {
+    queryClient.invalidateQueries({ queryKey: [key] });
+  });
+}
+
+function decrementOrReset(prev: number, intervalSeconds: number, queryClient: QueryClient): number {
+  if (prev <= 1) {
+    invalidateAnalyticsQueries(queryClient);
+    return intervalSeconds;
+  }
+  return prev - 1;
+}
+
 export default function AnalyticsAutoRefreshIndicator({
   intervalSeconds = DEFAULT_INTERVAL_SECONDS,
   className,
@@ -29,23 +43,14 @@ export default function AnalyticsAutoRefreshIndicator({
   useEffect(() => {
     setRemaining(intervalSeconds);
     const tick = setInterval(() => {
-      setRemaining((prev) => {
-        if (prev <= 1) {
-          ANALYTICS_QUERY_KEYS.forEach((key) => {
-            queryClient.invalidateQueries({ queryKey: [key] });
-          });
-          return intervalSeconds;
-        }
-        return prev - 1;
-      });
+      setRemaining((prev) => decrementOrReset(prev, intervalSeconds, queryClient));
     }, 1000);
 
     return () => clearInterval(tick);
   }, [intervalSeconds, queryClient]);
 
   return (
-    <div
-      role="status"
+    <output
       aria-live="polite"
       className={cn(
         "inline-flex items-center gap-1.5 rounded-full border border-[#E2E8F0] bg-white px-2.5 py-1 text-xs text-[#475569]",
@@ -62,6 +67,6 @@ export default function AnalyticsAutoRefreshIndicator({
           {formatCountdown(remaining)}
         </span>
       </span>
-    </div>
+    </output>
   );
 }

--- a/src/components/dashboard/Analytics/AnalyticsAutoRefreshIndicator.tsx
+++ b/src/components/dashboard/Analytics/AnalyticsAutoRefreshIndicator.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { cn } from "@/lib/utils";
+import { ANALYTICS_QUERY_KEYS } from "./analyticsQueryKeys";
+
+type Props = {
+  readonly intervalSeconds?: number;
+  readonly className?: string;
+};
+
+const DEFAULT_INTERVAL_SECONDS = 60;
+
+function formatCountdown(seconds: number): string {
+  const minutes = Math.floor(seconds / 60);
+  const remaining = seconds % 60;
+  if (minutes === 0) return `${remaining}s`;
+  return `${minutes}m ${String(remaining).padStart(2, "0")}s`;
+}
+
+export default function AnalyticsAutoRefreshIndicator({
+  intervalSeconds = DEFAULT_INTERVAL_SECONDS,
+  className,
+}: Props) {
+  const queryClient = useQueryClient();
+  const [remaining, setRemaining] = useState(intervalSeconds);
+
+  useEffect(() => {
+    setRemaining(intervalSeconds);
+    const tick = setInterval(() => {
+      setRemaining((prev) => {
+        if (prev <= 1) {
+          ANALYTICS_QUERY_KEYS.forEach((key) => {
+            queryClient.invalidateQueries({ queryKey: [key] });
+          });
+          return intervalSeconds;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(tick);
+  }, [intervalSeconds, queryClient]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-[#E2E8F0] bg-white px-2.5 py-1 text-xs text-[#475569]",
+        className,
+      )}
+    >
+      <span
+        className="h-1.5 w-1.5 rounded-full bg-[#22C55E]"
+        aria-hidden
+      />
+      <span className="whitespace-nowrap">
+        Atualiza em{" "}
+        <span className="inline-block w-8 text-center font-semibold tabular-nums text-[#0F172A]">
+          {formatCountdown(remaining)}
+        </span>
+      </span>
+    </div>
+  );
+}

--- a/src/components/dashboard/Analytics/AnalyticsFilters.tsx
+++ b/src/components/dashboard/Analytics/AnalyticsFilters.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import useDashboardStore from "@/states/dashboard";
+import AnalyticsPeriodSwitcher from "./AnalyticsPeriodSwitcher";
+import AnalyticsAutoRefreshIndicator from "./AnalyticsAutoRefreshIndicator";
+
+export default function AnalyticsFilters() {
+  const activeTab = useDashboardStore((state) => state.activeTab);
+  const activePeriod = useDashboardStore((state) => state.activePeriod);
+  const setActivePeriod = useDashboardStore((state) => state.setActivePeriod);
+
+  if (activeTab !== "analytics") return null;
+
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-3">
+      <AnalyticsPeriodSwitcher
+        value={activePeriod}
+        onChange={setActivePeriod}
+      />
+      {activePeriod === "hoje" && <AnalyticsAutoRefreshIndicator />}
+    </div>
+  );
+}

--- a/src/components/dashboard/Analytics/AnalyticsPeriodSwitcher.tsx
+++ b/src/components/dashboard/Analytics/AnalyticsPeriodSwitcher.tsx
@@ -1,0 +1,55 @@
+import { cn } from "@/lib/utils";
+import {
+  ANALYTICS_PERIODS,
+  type AnalyticsPeriod,
+} from "@/types/analyticsPeriod";
+
+type Props = {
+  readonly value: AnalyticsPeriod;
+  readonly onChange: (next: AnalyticsPeriod) => void;
+  readonly className?: string;
+  readonly name?: string;
+};
+
+export default function AnalyticsPeriodSwitcher({
+  value,
+  onChange,
+  className,
+  name = "analytics-period",
+}: Props) {
+  return (
+    <fieldset
+      className={cn(
+        "inline-flex items-stretch overflow-hidden rounded-lg border border-[#1E3A8A] bg-white",
+        className,
+      )}
+    >
+      <legend className="sr-only">Selecionar período</legend>
+      {ANALYTICS_PERIODS.map((period, index) => {
+        const isSelected = period.value === value;
+        return (
+          <label
+            key={period.value}
+            className={cn(
+              "inline-flex cursor-pointer items-center justify-center gap-2 px-6 py-2 text-sm font-bold transition-colors focus-within:ring-2 focus-within:ring-[#2563EB] focus-within:ring-inset",
+              index > 0 && "border-l border-[#1E3A8A]",
+              isSelected
+                ? "bg-[#1E3A8A] text-white"
+                : "bg-white text-[#1E3A8A] hover:bg-gray-50",
+            )}
+          >
+            <input
+              type="radio"
+              name={name}
+              value={period.value}
+              checked={isSelected}
+              onChange={() => onChange(period.value)}
+              className="sr-only"
+            />
+            {period.label}
+          </label>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/src/components/dashboard/Analytics/analyticsQueryKeys.ts
+++ b/src/components/dashboard/Analytics/analyticsQueryKeys.ts
@@ -1,0 +1,8 @@
+export const ANALYTICS_QUERY_KEYS: ReadonlyArray<string> = [
+  "active-users",
+  "average-session",
+  "peak-usage-today",
+  "users-by-page",
+  "device-distribution",
+  "peak-hours",
+];

--- a/src/components/dashboard/AverageSessionCard.tsx
+++ b/src/components/dashboard/AverageSessionCard.tsx
@@ -3,9 +3,11 @@
 import MetricCard from "@/components/dashboard/MetricCard";
 import { useAverageSession } from "@/hooks/useAverageSession";
 import type { MetricTrend } from "@/types/metric";
+import type { AnalyticsPeriod } from "@/types/analyticsPeriod";
 
 type Props = {
   readonly systemName?: string;
+  readonly period?: AnalyticsPeriod;
   readonly className?: string;
 };
 
@@ -28,9 +30,10 @@ function buildTrendLabel(
   return `${percentage}% ${suffix}`;
 }
 
-export default function AverageSessionCard({ systemName, className }: Props) {
+export default function AverageSessionCard({ systemName, period, className }: Props) {
   const { data, isLoading, isFetching, isError, refetch } = useAverageSession({
     systemName: systemName ?? "",
+    period,
   });
 
   return (

--- a/src/components/dashboard/DeviceDistributionCard.tsx
+++ b/src/components/dashboard/DeviceDistributionCard.tsx
@@ -13,9 +13,11 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useDeviceDistribution } from "@/hooks/useDeviceDistribution";
 import type { DeviceType } from "@/types/deviceDistribution";
+import type { AnalyticsPeriod } from "@/types/analyticsPeriod";
 
 type Props = {
   readonly systemName?: string;
+  readonly period?: AnalyticsPeriod;
   readonly className?: string;
 };
 
@@ -84,10 +86,11 @@ function WarningAlert({ message }: { readonly message: string }) {
 
 export default function DeviceDistributionCard({
   systemName,
+  period,
   className,
 }: Props) {
   const { data, isLoading, isFetching, isError, refetch } =
-    useDeviceDistribution({ systemName: systemName ?? "" });
+    useDeviceDistribution({ systemName: systemName ?? "", period });
 
   const content = () => {
     if (!systemName) {

--- a/src/components/dashboard/JenkinsJob/index.test.tsx
+++ b/src/components/dashboard/JenkinsJob/index.test.tsx
@@ -50,13 +50,9 @@ describe("<JenkinsJob />", () => {
     vi.restoreAllMocks();
   });
 
-  it("com múltiplos subprojetos: mostra select e atualiza automaticamente ao trocar", async () => {
+  it("com múltiplos subprojetos: mostra select de projeto e atualiza automaticamente ao trocar", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
       const url = fetchUrl(input);
-
-      if (url.startsWith("/api/jenkins/metrics?project=PTRF-FrontEnd&env=homolog")) {
-        return metricsResponse(99);
-      }
 
       if (url.startsWith("/api/jenkins/metrics?project=PTRF-BackEnd")) {
         return metricsResponse(1);
@@ -82,7 +78,7 @@ describe("<JenkinsJob />", () => {
     );
 
     expect(await screen.findByText("Projeto")).toBeInTheDocument();
-    expect(await screen.findByLabelText("Selecionar ambiente")).toHaveTextContent("Produção");
+    expect(screen.queryByLabelText("Selecionar ambiente")).not.toBeInTheDocument();
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
@@ -101,19 +97,64 @@ describe("<JenkinsJob />", () => {
         expect.any(Object)
       );
     });
+  });
 
-    const envTrigger = screen.getByLabelText("Selecionar ambiente");
-    fireEvent.click(envTrigger);
-    fireEvent.click(screen.getByText("Homologação"));
+  it("respeita o ambiente recebido via prop (homologacao → env=homolog)", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url = fetchUrl(input);
+
+      if (url.startsWith("/api/jenkins/metrics?project=PTRF-BackEnd&env=homolog")) {
+        return metricsResponse(1);
+      }
+
+      throw new Error(`fetch inesperado: ${url}`);
+    });
+
+    render(
+      withClient(
+        <JenkinsJob
+          project="SigEscola"
+          environment="homologacao"
+          subprojects={[{ label: "Backend", key: "PTRF-BackEnd" }]}
+        />
+      )
+    );
 
     await waitFor(() => {
       expect(fetchSpy).toHaveBeenCalledWith(
-        "/api/jenkins/metrics?project=PTRF-FrontEnd&env=homolog",
+        "/api/jenkins/metrics?project=PTRF-BackEnd&env=homolog",
         expect.any(Object)
       );
     });
+  });
 
-    expect(screen.getByLabelText("Selecionar ambiente")).toHaveTextContent("Homologação");
+  it("respeita o ambiente recebido via prop (qa → env=test)", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url = fetchUrl(input);
+
+      if (url.startsWith("/api/jenkins/metrics?project=PTRF-BackEnd&env=test")) {
+        return metricsResponse(1);
+      }
+
+      throw new Error(`fetch inesperado: ${url}`);
+    });
+
+    render(
+      withClient(
+        <JenkinsJob
+          project="SigEscola"
+          environment="qa"
+          subprojects={[{ label: "Backend", key: "PTRF-BackEnd" }]}
+        />
+      )
+    );
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/jenkins/metrics?project=PTRF-BackEnd&env=test",
+        expect.any(Object)
+      );
+    });
   });
 
   it("com apenas 1 subprojeto: não exige seleção adicional", async () => {

--- a/src/components/dashboard/JenkinsJob/index.tsx
+++ b/src/components/dashboard/JenkinsJob/index.tsx
@@ -12,12 +12,17 @@ import {
     SelectValue,
 } from "@/components/ui/select";
 import type { JenkinsSubproject } from "@/types/jenkinsSubproject";
+import {
+    getJenkinsEnvironmentForDeploy,
+    type DeployEnvironment,
+} from "@/types/deployEnvironment";
 
 const EMPTY_SUBPROJECTS: JenkinsSubproject[] = [];
 
 type Props = {
     readonly project: string;
     readonly subprojects?: JenkinsSubproject[];
+    readonly environment?: DeployEnvironment;
     readonly title?: string;
     readonly className?: string;
 };
@@ -27,6 +32,7 @@ export default function JenkinsJob({
     className,
     project,
     subprojects: subprojectsProp,
+    environment = "producao",
 }: Props) {
     const subprojects = useMemo(
         () => subprojectsProp ?? EMPTY_SUBPROJECTS,
@@ -35,7 +41,7 @@ export default function JenkinsJob({
     const hasMultipleSubprojects = subprojects.length > 1;
 
     const [selectedKey, setSelectedKey] = useState("");
-    const [environment, setEnvironment] = useState<"prod" | "homolog">("prod");
+    const jenkinsEnvironment = getJenkinsEnvironmentForDeploy(environment);
 
     useEffect(() => {
         if (!project || subprojects.length === 0) {
@@ -55,15 +61,15 @@ export default function JenkinsJob({
 
     const query = useJenkinsMetrics({
         projectName: selectedKey,
-        environment,
+        environment: jenkinsEnvironment,
     });
 
     if (!project) {
         return (
-            <JenkinsBranchBuildsCard 
-                title={title} 
-                className={className} 
-                projectName="" 
+            <JenkinsBranchBuildsCard
+                title={title}
+                className={className}
+                projectName=""
                 query={query}
             />
         );
@@ -83,29 +89,7 @@ export default function JenkinsJob({
     if (hasMultipleSubprojects) {
         return (
             <div className={cn("bg-white rounded-[5px] shadow-[3px_4px_6px_0px_rgba(0,0,0,0.1)] p-5", className)}>
-                <div className="flex items-center justify-between mb-4">
-                    <span className="font-bold text-[14px] text-[#111827]">{title}</span>
-                    <Select
-                        value={environment}
-                        onValueChange={(v) => setEnvironment(v === "homolog" ? "homolog" : "prod")}
-                    >
-                        <SelectTrigger
-                            size="sm"
-                            className="w-auto rounded-full border-transparent bg-slate-100 px-3 text-xs font-medium text-slate-700 shadow-none hover:bg-slate-200 gap-1"
-                            aria-label="Selecionar ambiente"
-                        >
-                            <SelectValue placeholder="Ambiente" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem value="prod" className="focus:bg-[#3b82f6] focus:text-white">
-                                Produção
-                            </SelectItem>
-                            <SelectItem value="homolog" className="focus:bg-[#3b82f6] focus:text-white">
-                                Homologação
-                            </SelectItem>
-                        </SelectContent>
-                    </Select>
-                </div>
+                <div className="font-bold text-[14px] text-[#111827] mb-4">{title}</div>
 
                 <div className="mb-4">
                     <div className="text-sm font-semibold text-[#111827] mb-2">Projeto</div>

--- a/src/components/dashboard/PeakHoursChart/index.tsx
+++ b/src/components/dashboard/PeakHoursChart/index.tsx
@@ -5,10 +5,12 @@ import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { usePeakHours } from "@/hooks/usePeakHours";
+import type { AnalyticsPeriod } from "@/types/analyticsPeriod";
 import Chart from "./Chart";
 
 type Props = {
   readonly systemName: string;
+  readonly period?: AnalyticsPeriod;
   readonly className?: string;
 };
 
@@ -37,9 +39,10 @@ function LoadingSkeleton({ className }: { readonly className?: string }) {
   );
 }
 
-export default function PeakHoursChart({ systemName, className }: Props) {
+export default function PeakHoursChart({ systemName, period, className }: Props) {
   const { data, isLoading, isFetching, isError, refetch } = usePeakHours({
     systemName,
+    period,
   });
 
   if (!systemName) {

--- a/src/components/dashboard/PeakUsageTodayCard/index.tsx
+++ b/src/components/dashboard/PeakUsageTodayCard/index.tsx
@@ -2,10 +2,16 @@
 
 import MetricCard from "@/components/dashboard/MetricCard";
 import { usePeakUsageToday } from "@/hooks/usePeakUsageToday";
+import {
+  DEFAULT_ANALYTICS_PERIOD,
+  getPeakCardTitle,
+  type AnalyticsPeriod,
+} from "@/types/analyticsPeriod";
 import { PeakStatusBadge } from "./PeakStatusBadge";
 
 type Props = {
   readonly systemName?: string;
+  readonly period?: AnalyticsPeriod;
   readonly className?: string;
 };
 
@@ -13,14 +19,19 @@ function formatPeakHour(hour: number) {
   return `${hour}h`;
 }
 
-export default function PeakUsageTodayCard({ systemName, className }: Props) {
+export default function PeakUsageTodayCard({
+  systemName,
+  period = DEFAULT_ANALYTICS_PERIOD,
+  className,
+}: Props) {
   const { data, isLoading, isFetching, isError, refetch } = usePeakUsageToday({
     systemName: systemName ?? "",
+    period,
   });
 
   return (
     <MetricCard
-      title="Pico de uso hoje"
+      title={getPeakCardTitle(period)}
       systemName={systemName}
       isLoading={isLoading || isFetching}
       isError={isError}

--- a/src/components/dashboard/SelectSistemas/getSistemasPorSquad.test.ts
+++ b/src/components/dashboard/SelectSistemas/getSistemasPorSquad.test.ts
@@ -95,10 +95,10 @@ describe("getSistemasPorSquad", () => {
         expect(portal?.jenkinsSubprojects).toEqual([{ label: "CEU", key: "CEU/php-fpm-prod" }]);
     });
 
-    it("inclui subprojeto para Rolê Agroecológico (main)", () => {
+    it("inclui subprojeto para Rolê Agroecológico (job no root)", () => {
         const sistemas = getSistemasPorSquad("CODAE");
         const role = sistemas.find((s) => s.nome === "Rolê Agroecológico");
-        expect(role?.jenkinsSubprojects).toEqual([{ label: "ROLE-AGROECOLOGICO", key: "ROLE-AGROECOLOGICO/main" }]);
+        expect(role?.jenkinsSubprojects).toEqual([{ label: "ROLE-AGROECOLOGICO", key: "ROLE-AGROECOLOGICO" }]);
     });
 
     it("inclui subprojeto para Autosserviço", () => {

--- a/src/components/dashboard/SelectSistemas/getSistemasPorSquad.ts
+++ b/src/components/dashboard/SelectSistemas/getSistemasPorSquad.ts
@@ -50,7 +50,7 @@ const JENKINS_SUBPROJECTS_BY_SQUAD_PROJECT: Record<string, Record<string, Jenkin
         "PLATEIA APP": [{ label: "SME-Plateia-App", key: "SME-Plateia-App" }],
     },
     CODAE: {
-        "ROLE AGROECOLOGICO": [{ label: "ROLE-AGROECOLOGICO", key: "ROLE-AGROECOLOGICO/main" }],
+        "ROLE AGROECOLOGICO": [{ label: "ROLE-AGROECOLOGICO", key: "ROLE-AGROECOLOGICO" }],
         SIGPAE: [
             { label: "Frontend", key: "Sigpae-Frontend-branchs" },
             { label: "Backend", key: "Sigpae-Backend" },

--- a/src/components/dashboard/SelectSistemas/index.tsx
+++ b/src/components/dashboard/SelectSistemas/index.tsx
@@ -13,7 +13,11 @@ import {
 import { Sistema } from "./schema";
 import { getSistemasPorSquad } from "./getSistemasPorSquad";
 
-export function SelectSistemas() {
+type Props = Readonly<{
+    rightSlot?: React.ReactNode;
+}>;
+
+export function SelectSistemas({ rightSlot }: Props = {}) {
     const activeItem = useDashboardStore((state) => state.activeItem);
     const setActiveProject = useDashboardStore(
         (state) => state.setActiveProject
@@ -64,29 +68,36 @@ export function SelectSistemas() {
                     <p className="pb-2">
                         Selecione um sistema para visualizar as informações
                     </p>
-                    <div id="onboarding-select-sistema" className="w-full pb-3">
-                        <Select
-                            value={selectedValue}
-                            onValueChange={(value) => {
-                                setSelectedValue(value);
-                                handleSelectChange(value);
-                            }}
-                        >
-                            <SelectTrigger className="w-full">
-                                <SelectValue placeholder="Selecione" />
-                            </SelectTrigger>
-                            <SelectContent>
-                                {sistemas.map((sistema) => (
-                                    <SelectItem
-                                        key={sistema.id}
-                                        value={sistema.id}
-                                        className="focus:bg-[#3b82f6] focus:text-white !focus:ring-0 !focus-visible:ring-0 focus:outline-none"
-                                    >
-                                        {sistema.nome}
-                                    </SelectItem>
-                                ))}
-                            </SelectContent>
-                        </Select>
+                    <div className="flex flex-col gap-3 pb-3 lg:flex-row lg:items-center">
+                        <div id="onboarding-select-sistema" className="w-full flex-1 min-w-0">
+                            <Select
+                                value={selectedValue}
+                                onValueChange={(value) => {
+                                    setSelectedValue(value);
+                                    handleSelectChange(value);
+                                }}
+                            >
+                                <SelectTrigger className="w-full">
+                                    <SelectValue placeholder="Selecione" />
+                                </SelectTrigger>
+                                <SelectContent>
+                                    {sistemas.map((sistema) => (
+                                        <SelectItem
+                                            key={sistema.id}
+                                            value={sistema.id}
+                                            className="focus:bg-[#3b82f6] focus:text-white !focus:ring-0 !focus-visible:ring-0 focus:outline-none"
+                                        >
+                                            {sistema.nome}
+                                        </SelectItem>
+                                    ))}
+                                </SelectContent>
+                            </Select>
+                        </div>
+                        {rightSlot && (
+                            <div className="flex shrink-0 items-center lg:justify-end">
+                                {rightSlot}
+                            </div>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/components/dashboard/UsersByPageCard.tsx
+++ b/src/components/dashboard/UsersByPageCard.tsx
@@ -15,9 +15,11 @@ import {
 import { cn } from "@/lib/utils";
 import { useUsersByPage } from "@/hooks/useUsersByPage";
 import type { UsersByPageEntry } from "@/types/usersByPage";
+import type { AnalyticsPeriod } from "@/types/analyticsPeriod";
 
 type Props = {
   readonly systemName?: string;
+  readonly period?: AnalyticsPeriod;
   readonly className?: string;
 };
 
@@ -192,9 +194,10 @@ function TableHeader({ sort, onSort }: TableHeaderProps) {
   );
 }
 
-export default function UsersByPageCard({ systemName, className }: Props) {
+export default function UsersByPageCard({ systemName, period, className }: Props) {
   const { data, isLoading, isFetching, isError, refetch } = useUsersByPage({
     systemName: systemName ?? "",
+    period,
   });
 
   const [selectedPath, setSelectedPath] = useState<string>(ALL_PAGES_VALUE);

--- a/src/hooks/useActiveUsers.ts
+++ b/src/hooks/useActiveUsers.ts
@@ -1,9 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import type { ActiveUsersResponse } from "@/types/activeUsers";
 import type { MetricTrend } from "@/types/metric";
+import {
+  DEFAULT_ANALYTICS_PERIOD,
+  type AnalyticsPeriod,
+} from "@/types/analyticsPeriod";
 
 type Options = {
   systemName: string;
+  period?: AnalyticsPeriod;
 };
 
 const AVERAGE_COUNT = 7563;
@@ -24,9 +29,12 @@ function pickRandomTrend(): MetricTrend {
   return trends[buffer[0] % trends.length];
 }
 
-export function useActiveUsers({ systemName }: Options) {
+export function useActiveUsers({
+  systemName,
+  period = DEFAULT_ANALYTICS_PERIOD,
+}: Options) {
   return useQuery<ActiveUsersResponse>({
-    queryKey: ["active-users", systemName],
+    queryKey: ["active-users", systemName, period],
     enabled: !!systemName,
     refetchOnWindowFocus: false,
     queryFn: async () => {

--- a/src/hooks/useAverageSession.ts
+++ b/src/hooks/useAverageSession.ts
@@ -1,9 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import type { AverageSessionResponse } from "@/types/averageSession";
 import type { MetricTrend } from "@/types/metric";
+import {
+  DEFAULT_ANALYTICS_PERIOD,
+  type AnalyticsPeriod,
+} from "@/types/analyticsPeriod";
 
 type Options = {
   systemName: string;
+  period?: AnalyticsPeriod;
 };
 
 const AVERAGE_SECONDS = 868;
@@ -21,9 +26,12 @@ function pickRandomTrend(): MetricTrend {
   return trends[buffer[0] % trends.length];
 }
 
-export function useAverageSession({ systemName }: Options) {
+export function useAverageSession({
+  systemName,
+  period = DEFAULT_ANALYTICS_PERIOD,
+}: Options) {
   return useQuery<AverageSessionResponse>({
-    queryKey: ["average-session", systemName],
+    queryKey: ["average-session", systemName, period],
     enabled: !!systemName,
     refetchOnWindowFocus: false,
     queryFn: async () => {

--- a/src/hooks/useDeviceDistribution.ts
+++ b/src/hooks/useDeviceDistribution.ts
@@ -1,8 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import type { DeviceDistributionResponse } from "@/types/deviceDistribution";
+import {
+  DEFAULT_ANALYTICS_PERIOD,
+  type AnalyticsPeriod,
+} from "@/types/analyticsPeriod";
 
 type Options = {
   systemName: string;
+  period?: AnalyticsPeriod;
 };
 
 const MOCK_RESPONSE: DeviceDistributionResponse = {
@@ -13,9 +18,12 @@ const MOCK_RESPONSE: DeviceDistributionResponse = {
   warning: "18% dos acessos via mobile, mas o sistema não é responsivo.",
 };
 
-export function useDeviceDistribution({ systemName }: Options) {
+export function useDeviceDistribution({
+  systemName,
+  period = DEFAULT_ANALYTICS_PERIOD,
+}: Options) {
   return useQuery<DeviceDistributionResponse>({
-    queryKey: ["device-distribution", systemName],
+    queryKey: ["device-distribution", systemName, period],
     enabled: !!systemName,
     refetchOnWindowFocus: false,
     queryFn: async () => {

--- a/src/hooks/useJenkinsMetrics.ts
+++ b/src/hooks/useJenkinsMetrics.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import type { JenkinsMetricsApiResponse } from "@/types/jenkins-metrics";
+import type { JenkinsEnvironment } from "@/types/deployEnvironment";
 
 type Options = {
   projectName: string;
-  environment?: "prod" | "homolog";
+  environment?: JenkinsEnvironment;
 };
 
 export function useJenkinsMetrics({ projectName, environment }: Options) {

--- a/src/hooks/usePeakHours.ts
+++ b/src/hooks/usePeakHours.ts
@@ -1,9 +1,14 @@
 import { useQuery } from "@tanstack/react-query";
 import type { PeakHoursResponse } from "@/types/peakHours";
 import { PEAK_HOURS_MOCK } from "@/components/dashboard/PeakHoursChart/mockData";
+import {
+  DEFAULT_ANALYTICS_PERIOD,
+  type AnalyticsPeriod,
+} from "@/types/analyticsPeriod";
 
 type Options = {
   systemName: string;
+  period?: AnalyticsPeriod;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -12,9 +17,12 @@ async function fetchPeakHours(systemName: string): Promise<PeakHoursResponse> {
   return PEAK_HOURS_MOCK;
 }
 
-export function usePeakHours({ systemName }: Options) {
+export function usePeakHours({
+  systemName,
+  period = DEFAULT_ANALYTICS_PERIOD,
+}: Options) {
   return useQuery<PeakHoursResponse>({
-    queryKey: ["peak-hours", systemName],
+    queryKey: ["peak-hours", systemName, period],
     enabled: !!systemName,
     refetchOnWindowFocus: false,
     queryFn: () => fetchPeakHours(systemName),

--- a/src/hooks/usePeakUsageToday.ts
+++ b/src/hooks/usePeakUsageToday.ts
@@ -3,9 +3,14 @@ import type {
   PeakUsageStatus,
   PeakUsageTodayResponse,
 } from "@/types/peakUsageToday";
+import {
+  DEFAULT_ANALYTICS_PERIOD,
+  type AnalyticsPeriod,
+} from "@/types/analyticsPeriod";
 
 type Options = {
   systemName: string;
+  period?: AnalyticsPeriod;
 };
 
 const MOCK_PEAK_HOUR = 15;
@@ -17,9 +22,12 @@ function pickRandomStatus(): PeakUsageStatus {
   return statuses[buffer[0] % statuses.length];
 }
 
-export function usePeakUsageToday({ systemName }: Options) {
+export function usePeakUsageToday({
+  systemName,
+  period = DEFAULT_ANALYTICS_PERIOD,
+}: Options) {
   return useQuery<PeakUsageTodayResponse>({
-    queryKey: ["peak-usage-today", systemName],
+    queryKey: ["peak-usage-today", systemName, period],
     enabled: !!systemName,
     refetchOnWindowFocus: false,
     queryFn: async () => {

--- a/src/hooks/useUsersByPage.ts
+++ b/src/hooks/useUsersByPage.ts
@@ -1,8 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import type { UsersByPageResponse } from "@/types/usersByPage";
+import {
+  DEFAULT_ANALYTICS_PERIOD,
+  type AnalyticsPeriod,
+} from "@/types/analyticsPeriod";
 
 type Options = {
   systemName: string;
+  period?: AnalyticsPeriod;
 };
 
 const MOCK_PAGES: UsersByPageResponse["pages"] = [
@@ -18,9 +23,12 @@ const MOCK_PAGES: UsersByPageResponse["pages"] = [
   { path: "/Ajuda", currentUsers: 513, averageUsers: 1305 },
 ];
 
-export function useUsersByPage({ systemName }: Options) {
+export function useUsersByPage({
+  systemName,
+  period = DEFAULT_ANALYTICS_PERIOD,
+}: Options) {
   return useQuery<UsersByPageResponse>({
-    queryKey: ["users-by-page", systemName],
+    queryKey: ["users-by-page", systemName, period],
     enabled: !!systemName,
     refetchOnWindowFocus: false,
     queryFn: async () => {

--- a/src/states/dashboard.ts
+++ b/src/states/dashboard.ts
@@ -1,6 +1,11 @@
 // src/states/dashboard.ts
 import { create } from "zustand";
 import type { JenkinsSubproject } from "@/types/jenkinsSubproject";
+import {
+    DEFAULT_ANALYTICS_PERIOD,
+    type AnalyticsPeriod,
+    type DashboardTab,
+} from "@/types/analyticsPeriod";
 
 export interface SidebarItem {
     title: string;
@@ -24,6 +29,8 @@ export interface ProjectItem {
 type State = {
     activeItem: SidebarItem | null;
     activeProject: ProjectItem | null;
+    activeTab: DashboardTab;
+    activePeriod: AnalyticsPeriod;
 };
 
 type Action = {
@@ -31,15 +38,21 @@ type Action = {
     clearActiveItem: () => void;
     setActiveProject: (project: ProjectItem | null) => void;
     clearActiveProject: () => void;
+    setActiveTab: (tab: DashboardTab) => void;
+    setActivePeriod: (period: AnalyticsPeriod) => void;
 };
 
 // Inicialmente nulo (vamos setar depois com base no allowedSquads)
 export default create<State & Action>((set) => ({
     activeItem: null,
     activeProject: null,
+    activeTab: "operacional",
+    activePeriod: DEFAULT_ANALYTICS_PERIOD,
 
     setActiveItem: (activeItem) => set({ activeItem }),
     clearActiveItem: () => set({ activeItem: null }),
     setActiveProject: (activeProject) => set({ activeProject }),
     clearActiveProject: () => set({ activeProject: null }),
+    setActiveTab: (activeTab) => set({ activeTab }),
+    setActivePeriod: (activePeriod) => set({ activePeriod }),
 }));

--- a/src/types/analyticsPeriod.ts
+++ b/src/types/analyticsPeriod.ts
@@ -1,0 +1,36 @@
+export type AnalyticsPeriod = "hoje" | "7-dias" | "30-dias";
+
+export type AnalyticsPeriodInfo = {
+  value: AnalyticsPeriod;
+  label: string;
+  peakCardTitle: string;
+};
+
+export const ANALYTICS_PERIODS: ReadonlyArray<AnalyticsPeriodInfo> = [
+  {
+    value: "hoje",
+    label: "Hoje",
+    peakCardTitle: "Pico de uso hoje",
+  },
+  {
+    value: "7-dias",
+    label: "7 dias",
+    peakCardTitle: "Dia de maior pico",
+  },
+  {
+    value: "30-dias",
+    label: "30 dias",
+    peakCardTitle: "Período de maior pico",
+  },
+];
+
+export const DEFAULT_ANALYTICS_PERIOD: AnalyticsPeriod = "hoje";
+
+export function getPeakCardTitle(period: AnalyticsPeriod): string {
+  return (
+    ANALYTICS_PERIODS.find((p) => p.value === period)?.peakCardTitle ??
+    ANALYTICS_PERIODS[0].peakCardTitle
+  );
+}
+
+export type DashboardTab = "operacional" | "analytics" | "saude-deploy";

--- a/src/types/deployEnvironment.ts
+++ b/src/types/deployEnvironment.ts
@@ -1,11 +1,14 @@
 export type DeployEnvironment = "producao" | "homologacao" | "qa";
 
+export type JenkinsEnvironment = "prod" | "homolog" | "test";
+
 export type DeployEnvironmentInfo = {
   value: DeployEnvironment;
   label: string;
   dotClassName: string;
   branch: string;
   sonarBranches: readonly string[];
+  jenkinsEnvironment: JenkinsEnvironment;
 };
 
 export const DEPLOY_ENVIRONMENTS: ReadonlyArray<DeployEnvironmentInfo> = [
@@ -15,6 +18,7 @@ export const DEPLOY_ENVIRONMENTS: ReadonlyArray<DeployEnvironmentInfo> = [
     dotClassName: "bg-red-500",
     branch: "Master",
     sonarBranches: ["master", "main"],
+    jenkinsEnvironment: "prod",
   },
   {
     value: "homologacao",
@@ -22,15 +26,26 @@ export const DEPLOY_ENVIRONMENTS: ReadonlyArray<DeployEnvironmentInfo> = [
     dotClassName: "bg-amber-400",
     branch: "Homolog",
     sonarBranches: ["homolog"],
+    jenkinsEnvironment: "homolog",
   },
   {
     value: "qa",
     label: "QA",
     dotClassName: "bg-green-500",
     branch: "QA",
-    sonarBranches: ["test"],
+    sonarBranches: ["testes", "test", "teste", "develop"],
+    jenkinsEnvironment: "test",
   },
 ];
+
+export function getJenkinsEnvironmentForDeploy(
+  env: DeployEnvironment
+): JenkinsEnvironment {
+  return (
+    DEPLOY_ENVIRONMENTS.find((e) => e.value === env)?.jenkinsEnvironment ??
+    "prod"
+  );
+}
 
 export function getSonarBranchesForEnvironment(env: DeployEnvironment): readonly string[] {
   return (


### PR DESCRIPTION
[AB#148105](https://dev.azure.com/SME-Spassu/COTIC%20-%20Desenvolvimento/_sprints/taskboard/COTIC%20-%20Desenvolvimento%20Team/COTIC%20-%20Desenvolvimento/Ciclo%20012%20-%20Mai26?workitem=148105)

## Resumo
Adiciona um filtro de período (Hoje / 7 dias / 30 dias) ao lado do seletor de sistema, visível somente quando a aba Analytics está ativa. O período selecionado é mantido no Zustand e propagado para todos os indicadores da aba, fazendo cada um refletir o intervalo escolhido. O título do terceiro card de destaque adapta-se ao período: *Pico de uso hoje* (Hoje), *Dia de maior pico* (7 dias) e *Período de maior pico* (30 dias). Um indicador de atualização automática (countdown de 60s que invalida as queries da aba) é exibido apenas no período Hoje.

Junto disso, o card Jenkins na aba Saúde do deploy deixa de manter seletor de ambiente próprio e passa a respeitar o switch global da página. O backend Jenkins ganha suporte ao ambiente QA (mapeado para a branch `test`), com candidatos de fallback `test`, `teste`, `testes`, `qa`, `develop` e `dev` — atendendo às convenções de cada sistema (Sigpae usa `testes`, Novo SGP usa `teste`, Plateia usa `develop`). O ambiente prod também passa a considerar jobs no root, resolvendo projetos como Rolê Agroecológico que não seguem o padrão multibranch. As branches de fallback do SonarQube para QA são expandidas com a mesma estratégia.

## Como testar
- Abrir a aba **Analytics**: validar que o filtro de período aparece ao lado do seletor de sistema, o período padrão é **Hoje**, e o badge *Atualiza em XXs* é exibido somente nesse período
- Alternar entre **Hoje**, **7 dias** e **30 dias** e confirmar que os cards (Usuários ativos, Média de sessão, Pico de uso, Usuários por página, Tipo de dispositivo e Horários de pico) são atualizados; verificar a mudança do título do terceiro card
- Trocar de aba e voltar para Analytics: o filtro deve continuar visível e o período preservado
- Abrir a aba **Saúde do deploy**: confirmar que o card Jenkins não tem mais seletor de ambiente próprio
- Alternar entre **Produção**, **Homologação** e **QA** e validar que tanto Jenkins quanto SonarQube atualizam para a branch correspondente
- Selecionar **Rolê Agroecológico** em produção e validar que o card Jenkins resolve o job no root (`/job/ROLE-AGROECOLOGICO/`)
- Selecionar **SigPAE Frontend** em QA e validar que o Jenkins resolve para a branch `testes`