### PR TITLE
Feature/149274: Onboarding saude do deploy

### DIFF
--- a/src/app/dashboard/DashboardShell.tsx
+++ b/src/app/dashboard/DashboardShell.tsx
@@ -1,19 +1,20 @@
 "use client";
 
-import { SessionProvider } from "next-auth/react";
-import type { Session } from "next-auth";
+import AnalyticsFilters from "@/components/dashboard/Analytics/AnalyticsFilters";
+import { DeployHealthTourOverlay } from "@/components/dashboard/Onboarding/DeployHealthTourOverlay";
+import { TourOverlay } from "@/components/dashboard/Onboarding/TourOverlay";
+import { WelcomeModal } from "@/components/dashboard/Onboarding/WelcomeModal";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { SelectSistemas } from "@/components/dashboard/SelectSistemas";
+import { SessionGuard } from "@/components/dashboard/SessionGuard";
+import { AppSidebar } from "@/components/dashboard/Sidebar/app-sidebar";
 import {
     SidebarInset,
     SidebarProvider,
     SidebarTrigger,
 } from "@/components/ui/sidebar";
-import { AppSidebar } from "@/components/dashboard/Sidebar/app-sidebar";
-import { PageHeader } from "@/components/dashboard/page-header";
-import { SelectSistemas } from "@/components/dashboard/SelectSistemas";
-import AnalyticsFilters from "@/components/dashboard/Analytics/AnalyticsFilters";
-import { WelcomeModal } from "@/components/dashboard/Onboarding/WelcomeModal";
-import { TourOverlay } from "@/components/dashboard/Onboarding/TourOverlay";
-import { SessionGuard } from "@/components/dashboard/SessionGuard";
+import type { Session } from "next-auth";
+import { SessionProvider } from "next-auth/react";
 
 type DashboardShellProps = Readonly<{
     children: React.ReactNode;
@@ -41,6 +42,7 @@ export function DashboardShell({ children, session }: DashboardShellProps) {
                     </SidebarInset>
                     <WelcomeModal />
                     <TourOverlay />
+                    <DeployHealthTourOverlay />
                 </SidebarProvider>
             </SessionGuard>
         </SessionProvider>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -1,215 +1,276 @@
 // src/app/dashboard/page.test.tsx
 /* @vitest-environment jsdom */
-import { fireEvent, render, screen } from "@testing-library/react";
-import { vi, describe, test, beforeEach } from "vitest";
-import Dashboard from "./page";
 import { withClient } from "@/__mocks__/renderWithClient";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, test, vi } from "vitest";
+import Dashboard from "./page";
 
 // 🔧 Mock do store com estado configurável por teste
 type StoreState = {
-  activeItem?: null | {
-    title?: string;
-  };
-  activeProject: null | {
-    nome?: string;
-    zabbixQueryFrontend?: string;
-    zabbixQueryBackend?: string;
-    zabbixQueryFilasRabbitMQ?: string;
-    sonarProjectKey?: string;
-    zabbixQueryJenkinsJob?: string;
-    jenkinsSubprojects?: unknown[];
-  };
-  activeTab?: string;
-  activePeriod?: string;
-  setActiveTab?: (tab: string) => void;
-  setActivePeriod?: (period: string) => void;
+    activeItem?: null | {
+        title?: string;
+    };
+    activeProject: null | {
+        nome?: string;
+        zabbixQueryFrontend?: string;
+        zabbixQueryBackend?: string;
+        zabbixQueryFilasRabbitMQ?: string;
+        sonarProjectKey?: string;
+        zabbixQueryJenkinsJob?: string;
+        jenkinsSubprojects?: unknown[];
+    };
+    activeTab?: string;
+    activePeriod?: string;
+    setActiveTab?: (tab: string) => void;
+    setActivePeriod?: (period: string) => void;
 };
 let mockStoreState: StoreState = {
-  activeItem: { title: "COPED" },
-  activeProject: {
-    nome: "Novo SGP",
-    zabbixQueryFrontend: "Portal SME",
-    zabbixQueryBackend: "API SME",
-    zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
-  },
-  activeTab: "operacional",
-  activePeriod: "hoje",
-  setActiveTab: (tab) => {
-    mockStoreState = { ...mockStoreState, activeTab: tab };
-  },
-  setActivePeriod: (period) => {
-    mockStoreState = { ...mockStoreState, activePeriod: period };
-  },
+    activeItem: { title: "COPED" },
+    activeProject: {
+        nome: "Novo SGP",
+        zabbixQueryFrontend: "Portal SME",
+        zabbixQueryBackend: "API SME",
+        zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
+    },
+    activeTab: "operacional",
+    activePeriod: "hoje",
+    setActiveTab: (tab) => {
+        mockStoreState = { ...mockStoreState, activeTab: tab };
+    },
+    setActivePeriod: (period) => {
+        mockStoreState = { ...mockStoreState, activePeriod: period };
+    },
 };
 
 vi.mock("@/states/dashboard", () => ({
-  __esModule: true,
-  default: (selector: (s: StoreState) => unknown) => selector(mockStoreState),
+    __esModule: true,
+    default: (selector: (s: StoreState) => unknown) => selector(mockStoreState),
 }));
 
 // 🔧 Mocks simples dos filhos
 vi.mock("@/components/dashboard/CardWrapperInfoAmbientes", () => ({
-  __esModule: true,
-  default: ({ title, children }: { title: string; children: React.ReactNode }) => (
-    <section data-testid={`card-${title}`}>{children}</section>
-  ),
+    __esModule: true,
+    default: ({
+        title,
+        children,
+    }: {
+        title: string;
+        children: React.ReactNode;
+    }) => <section data-testid={`card-${title}`}>{children}</section>,
 }));
 
 vi.mock("@/components/dashboard/DisponibilidadeDosAmbientes/Producao", () => ({
-  __esModule: true,
-  default: ({ title, projectName }: { title?: string; projectName: string }) => (
-    <div data-testid={`producao-${title ?? "Frontend"}`}>{projectName}</div>
-  ),
+    __esModule: true,
+    default: ({
+        title,
+        projectName,
+    }: {
+        title?: string;
+        projectName: string;
+    }) => (
+        <div data-testid={`producao-${title ?? "Frontend"}`}>{projectName}</div>
+    ),
 }));
 
 vi.mock("@/components/dashboard/SaudeDosServidores/Filas", () => ({
-  __esModule: true,
-  default: ({ title, projectName }: { title: string; projectName: string }) => (
-    <div data-testid={`filas-${title ?? "Filas"}`}>{projectName}</div>
-  ),
+    __esModule: true,
+    default: ({
+        title,
+        projectName,
+    }: {
+        title: string;
+        projectName: string;
+    }) => <div data-testid={`filas-${title ?? "Filas"}`}>{projectName}</div>,
 }));
 
 vi.mock("@/components/dashboard/JenkinsJob", () => ({
-  __esModule: true,
-  default: ({ title, project, subprojects }: { title?: string; project: string; subprojects?: unknown[] }) => (
-    <div data-testid={`jenkins-${title ?? "Jenkins - Branches e Builds"}`}>
-      {project}::{Array.isArray(subprojects) ? subprojects.length : 0}
-    </div>
-  ),
+    __esModule: true,
+    default: ({
+        title,
+        project,
+        subprojects,
+    }: {
+        title?: string;
+        project: string;
+        subprojects?: unknown[];
+    }) => (
+        <div data-testid={`jenkins-${title ?? "Jenkins - Branches e Builds"}`}>
+            {project}::{Array.isArray(subprojects) ? subprojects.length : 0}
+        </div>
+    ),
 }));
 
 vi.mock("@/components/dashboard/DeployHealth/EnvironmentHeader", () => ({
-  __esModule: true,
-  default: () => <div data-testid="environment-header">Ambiente</div>,
+    __esModule: true,
+    default: () => <div data-testid="environment-header">Ambiente</div>,
 }));
 
-vi.mock("@/components/dashboard/DeployHealth/SonarQuality/SonarQualityIndicatorsCard", () => ({
-  __esModule: true,
-  default: ({ projectName, className }: { projectName: string; className?: string }) => (
-    <div data-testid="sonar-quality" className={className}>
-      {projectName}
-    </div>
-  ),
-}));
+vi.mock(
+    "@/components/dashboard/DeployHealth/SonarQuality/SonarQualityIndicatorsCard",
+    () => ({
+        __esModule: true,
+        default: ({
+            projectName,
+            className,
+        }: {
+            projectName: string;
+            className?: string;
+        }) => (
+            <div data-testid="sonar-quality" className={className}>
+                {projectName}
+            </div>
+        ),
+    }),
+);
 
 vi.mock("@/components/dashboard/DatabaseStatusCard", () => ({
-  __esModule: true,
-  default: ({ systemName }: { systemName?: string }) => (
-    <div data-testid="database-status-card">{systemName ?? ""}</div>
-  ),
+    __esModule: true,
+    default: ({ systemName }: { systemName?: string }) => (
+        <div data-testid="database-status-card">{systemName ?? ""}</div>
+    ),
 }));
 
 describe("Dashboard page", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockStoreState = {
-      activeItem: { title: "COPED" },
-      activeProject: {
-        nome: "Novo SGP",
-        zabbixQueryFrontend: "Portal SME",
-        zabbixQueryBackend: "API SME",
-        zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
-      },
-      activeTab: "operacional",
-      activePeriod: "hoje",
-      setActiveTab: (tab) => {
-        mockStoreState = { ...mockStoreState, activeTab: tab };
-      },
-      setActivePeriod: (period) => {
-        mockStoreState = { ...mockStoreState, activePeriod: period };
-      },
-    };
-  });
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockStoreState = {
+            activeItem: { title: "COPED" },
+            activeProject: {
+                nome: "Novo SGP",
+                zabbixQueryFrontend: "Portal SME",
+                zabbixQueryBackend: "API SME",
+                zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
+            },
+            activeTab: "operacional",
+            activePeriod: "hoje",
+            setActiveTab: (tab) => {
+                mockStoreState = { ...mockStoreState, activeTab: tab };
+            },
+            setActivePeriod: (period) => {
+                mockStoreState = { ...mockStoreState, activePeriod: period };
+            },
+        };
+    });
 
-  test("renderiza os cards e passa os nomes de projeto corretos", () => {
-    render(withClient(<Dashboard />));
+    test("renderiza os cards e passa os nomes de projeto corretos", () => {
+        render(withClient(<Dashboard />));
 
-    // Primeiro card (Frontend)
-    expect(screen.getByTestId("card-Disponibilidade do ambiente")).toBeInTheDocument();
-    expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("Portal SME");
+        // Primeiro card (Frontend)
+        expect(
+            screen.getByTestId("card-Disponibilidade do ambiente"),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId("producao-Frontend")).toHaveTextContent(
+            "Portal SME",
+        );
 
-    // Segundo card (Saúde do servidor)
-    expect(screen.getByTestId("card-Saúde do servidor (Workloads)")).toBeInTheDocument();
-    expect(screen.getByTestId("producao-API Service")).toHaveTextContent("API SME");
+        // Segundo card (Saúde do servidor)
+        expect(
+            screen.getByTestId("card-Saúde do servidor (Workloads)"),
+        ).toBeInTheDocument();
+        expect(screen.getByTestId("producao-API Service")).toHaveTextContent(
+            "API SME",
+        );
 
-    // Filas
-    expect(screen.getByTestId("filas-Fila")).toHaveTextContent("Filas RabbitMQ");
+        // Filas
+        expect(screen.getByTestId("filas-Fila")).toHaveTextContent(
+            "Filas RabbitMQ",
+        );
 
-    // Banco de dados
-    expect(screen.getByTestId("database-status-card")).toHaveTextContent("Novo SGP");
-  });
+        // Banco de dados
+        expect(screen.getByTestId("database-status-card")).toHaveTextContent(
+            "Novo SGP",
+        );
+    });
 
-  test("renderiza Jenkins - Branches e Builds na aba Saúde do deploy à esquerda do Sonar", () => {
-    mockStoreState = {
-      ...mockStoreState,
-      activeItem: { title: "COPED" },
-      activeProject: {
-        nome: "Novo SGP",
-        zabbixQueryFrontend: "Portal SME",
-        zabbixQueryBackend: "API SME",
-        zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
-        jenkinsSubprojects: [{ label: "Backend", key: "SME-NovoSGP/master" }],
-      },
-    };
+    test("renderiza Jenkins - Branches e Builds na aba Saúde do deploy à esquerda do Sonar", () => {
+        mockStoreState = {
+            ...mockStoreState,
+            activeItem: { title: "COPED" },
+            activeProject: {
+                nome: "Novo SGP",
+                zabbixQueryFrontend: "Portal SME",
+                zabbixQueryBackend: "API SME",
+                zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
+                jenkinsSubprojects: [
+                    { label: "Backend", key: "SME-NovoSGP/master" },
+                ],
+            },
+        };
 
-    render(withClient(<Dashboard />));
+        render(withClient(<Dashboard />));
 
-    fireEvent.click(screen.getByRole("tab", { name: "Saúde do deploy" }));
+        fireEvent.click(screen.getByRole("tab", { name: "Saúde do deploy" }));
 
-    const jenkins = screen.getByTestId("jenkins-Jenkins - Branches e Builds");
-    const sonar = screen.getByTestId("sonar-quality");
+        const jenkins = screen.getByTestId(
+            "jenkins-Jenkins - Branches e Builds",
+        );
+        const sonar = screen.getByTestId("sonar-quality");
 
-    expect(jenkins).toHaveTextContent("Novo SGP::1");
-    expect(jenkins.parentElement).toHaveClass("lg:col-span-1");
-    expect(sonar).toHaveClass("lg:col-span-3");
-  });
+        expect(jenkins).toHaveTextContent("Novo SGP::1");
+        expect(jenkins.parentElement).toHaveClass("lg:col-span-1");
+        expect(sonar.parentElement).toHaveClass("lg:col-span-3");
+    });
 
-  test("quando não há projeto ativo, passa strings vazias para os filhos (ramo do ??)", () => {
-    mockStoreState = { ...mockStoreState, activeProject: null };
+    test("quando não há projeto ativo, passa strings vazias para os filhos (ramo do ??)", () => {
+        mockStoreState = { ...mockStoreState, activeProject: null };
 
-    render(withClient(<Dashboard />));
+        render(withClient(<Dashboard />));
 
-    expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("");
-    expect(screen.getByTestId("producao-API Service")).toHaveTextContent("");
-    expect(screen.getByTestId("filas-Fila")).toHaveTextContent("");
-    expect(screen.getByTestId("database-status-card")).toHaveTextContent("");
-  });
+        expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("");
+        expect(screen.getByTestId("producao-API Service")).toHaveTextContent(
+            "",
+        );
+        expect(screen.getByTestId("filas-Fila")).toHaveTextContent("");
+        expect(screen.getByTestId("database-status-card")).toHaveTextContent(
+            "",
+        );
+    });
 
-  test("trima os nomes antes de passar (ramo do ?.trim())", () => {
-    mockStoreState = {
-      ...mockStoreState,
-      activeItem: { title: "COPED" },
-      activeProject: {
-        nome: "   Novo SGP   ",
-        zabbixQueryFrontend: "   Portal SME   ",
-        zabbixQueryBackend: "   API SME   ",
-        zabbixQueryFilasRabbitMQ: "   Filas RabbitMQ   ",
-      },
-    };
+    test("trima os nomes antes de passar (ramo do ?.trim())", () => {
+        mockStoreState = {
+            ...mockStoreState,
+            activeItem: { title: "COPED" },
+            activeProject: {
+                nome: "   Novo SGP   ",
+                zabbixQueryFrontend: "   Portal SME   ",
+                zabbixQueryBackend: "   API SME   ",
+                zabbixQueryFilasRabbitMQ: "   Filas RabbitMQ   ",
+            },
+        };
 
-    render(withClient(<Dashboard />));
+        render(withClient(<Dashboard />));
 
-    expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("Portal SME");
-    expect(screen.getByTestId("producao-API Service")).toHaveTextContent("API SME");
-    expect(screen.getByTestId("filas-Fila")).toHaveTextContent("Filas RabbitMQ");
-  });
+        expect(screen.getByTestId("producao-Frontend")).toHaveTextContent(
+            "Portal SME",
+        );
+        expect(screen.getByTestId("producao-API Service")).toHaveTextContent(
+            "API SME",
+        );
+        expect(screen.getByTestId("filas-Fila")).toHaveTextContent(
+            "Filas RabbitMQ",
+        );
+    });
 
-  test("quando um campo específico está undefined, cai no fallback vazio para aquele filho", () => {
-    mockStoreState = {
-      ...mockStoreState,
-      activeItem: { title: "COPED" },
-      activeProject: {
-        nome: "Novo SGP",
-        zabbixQueryFrontend: "Portal SME",
-        zabbixQueryBackend: "API SME",
-        // RabbitMQ ausente → deve virar ""
-      },
-    };
+    test("quando um campo específico está undefined, cai no fallback vazio para aquele filho", () => {
+        mockStoreState = {
+            ...mockStoreState,
+            activeItem: { title: "COPED" },
+            activeProject: {
+                nome: "Novo SGP",
+                zabbixQueryFrontend: "Portal SME",
+                zabbixQueryBackend: "API SME",
+                // RabbitMQ ausente → deve virar ""
+            },
+        };
 
-    render(withClient(<Dashboard />));
+        render(withClient(<Dashboard />));
 
-    expect(screen.getByTestId("producao-Frontend")).toHaveTextContent("Portal SME");
-    expect(screen.getByTestId("producao-API Service")).toHaveTextContent("API SME");
-    expect(screen.getByTestId("filas-Fila")).toHaveTextContent(""); // fallback
-  });
+        expect(screen.getByTestId("producao-Frontend")).toHaveTextContent(
+            "Portal SME",
+        );
+        expect(screen.getByTestId("producao-API Service")).toHaveTextContent(
+            "API SME",
+        );
+        expect(screen.getByTestId("filas-Fila")).toHaveTextContent(""); // fallback
+    });
 });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,23 +1,24 @@
 "use client";
-import CardWrapperInfoAmbientes from "@/components/dashboard/CardWrapperInfoAmbientes";
-import Producao from "@/components/dashboard/DisponibilidadeDosAmbientes/Producao";
-import Filas from "@/components/dashboard/SaudeDosServidores/Filas";
-import DatabaseStatusCard from "@/components/dashboard/DatabaseStatusCard";
-import JenkinsJob from "@/components/dashboard/JenkinsJob";
-import AzureDevOpsBacklog from "@/components/dashboard/AzureDevOpsBacklog";
-import PeakHoursChart from "@/components/dashboard/PeakHoursChart";
-import AverageSessionCard from "@/components/dashboard/AverageSessionCard";
 import ActiveUsersCard from "@/components/dashboard/ActiveUsersCard";
-import DeviceDistributionCard from "@/components/dashboard/DeviceDistributionCard";
-import UsersByPageCard from "@/components/dashboard/UsersByPageCard";
-import PeakUsageTodayCard from "@/components/dashboard/PeakUsageTodayCard";
+import AverageSessionCard from "@/components/dashboard/AverageSessionCard";
+import AzureDevOpsBacklog from "@/components/dashboard/AzureDevOpsBacklog";
+import CardWrapperInfoAmbientes from "@/components/dashboard/CardWrapperInfoAmbientes";
+import DatabaseStatusCard from "@/components/dashboard/DatabaseStatusCard";
 import EnvironmentHeader from "@/components/dashboard/DeployHealth/EnvironmentHeader";
 import SonarQualityIndicatorsCard from "@/components/dashboard/DeployHealth/SonarQuality/SonarQualityIndicatorsCard";
+import DeviceDistributionCard from "@/components/dashboard/DeviceDistributionCard";
+import Producao from "@/components/dashboard/DisponibilidadeDosAmbientes/Producao";
+import JenkinsJob from "@/components/dashboard/JenkinsJob";
+import PeakHoursChart from "@/components/dashboard/PeakHoursChart";
+import PeakUsageTodayCard from "@/components/dashboard/PeakUsageTodayCard";
+import Filas from "@/components/dashboard/SaudeDosServidores/Filas";
+import UsersByPageCard from "@/components/dashboard/UsersByPageCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useDeployHealthOnboarding } from "@/hooks/useDeployHealthOnboarding";
 import useDashboardStore from "@/states/dashboard";
-import { useState } from "react";
-import type { DeployEnvironment } from "@/types/deployEnvironment";
 import type { DashboardTab } from "@/types/analyticsPeriod";
+import type { DeployEnvironment } from "@/types/deployEnvironment";
+import { useState } from "react";
 
 type FullWidthSectionProps = {
     readonly id?: string;
@@ -26,7 +27,12 @@ type FullWidthSectionProps = {
     readonly children: React.ReactNode;
 };
 
-function FullWidthSection({ id, title, tooltip, children }: FullWidthSectionProps) {
+function FullWidthSection({
+    id,
+    title,
+    tooltip,
+    children,
+}: FullWidthSectionProps) {
     return (
         <div className="grid grid-cols-4 gap-4">
             <CardWrapperInfoAmbientes
@@ -46,22 +52,31 @@ export default function Dashboard() {
     const setActiveTab = useDashboardStore((state) => state.setActiveTab);
     const activePeriod = useDashboardStore((state) => state.activePeriod);
     const projectName = activeProject?.nome?.trim() ?? "";
-    const projectNameFrontEnd = activeProject?.zabbixQueryFrontend?.trim() ?? "";
+    const projectNameFrontEnd =
+        activeProject?.zabbixQueryFrontend?.trim() ?? "";
     const projectNameBackEnd = activeProject?.zabbixQueryBackend?.trim() ?? "";
-    const projectNameFilasRabbitMQ = activeProject?.zabbixQueryFilasRabbitMQ?.trim() ?? "";
+    const projectNameFilasRabbitMQ =
+        activeProject?.zabbixQueryFilasRabbitMQ?.trim() ?? "";
     const jenkinsSubprojects = activeProject?.jenkinsSubprojects ?? [];
-    const [deployEnvironment, setDeployEnvironment] = useState<DeployEnvironment>("producao");
+    const [deployEnvironment, setDeployEnvironment] =
+        useState<DeployEnvironment>("producao");
+    const { triggerDeployTour } = useDeployHealthOnboarding();
 
     return (
         <div className="bg-background px-6 py-4">
             <Tabs
                 defaultValue="operacional"
-                onValueChange={(value) => setActiveTab(value as DashboardTab)}
+                onValueChange={(value) => {
+                    setActiveTab(value as DashboardTab);
+                    if (value === "saude-deploy") triggerDeployTour();
+                }}
             >
                 <TabsList className="mb-6 px-1">
                     <TabsTrigger value="operacional">Operacional</TabsTrigger>
                     <TabsTrigger value="analytics">Analytics</TabsTrigger>
-                    <TabsTrigger value="saude-deploy">Saúde do deploy</TabsTrigger>
+                    <TabsTrigger value="saude-deploy">
+                        Saúde do deploy
+                    </TabsTrigger>
                 </TabsList>
 
                 <TabsContent value="operacional">
@@ -73,11 +88,15 @@ export default function Dashboard() {
                             tooltipContent={
                                 <>
                                     <p className="mb-4">
-                                        Essa seção monitora se o sistema está funcionando e acessível aos usuários.
-                                        Disponibilidade significa que o sistema está no ar e pronto para uso, sem interrupções.
+                                        Essa seção monitora se o sistema está
+                                        funcionando e acessível aos usuários.
+                                        Disponibilidade significa que o sistema
+                                        está no ar e pronto para uso, sem
+                                        interrupções.
                                     </p>
                                     <p>
-                                        Os ambientes podem estar Disponível, Indisponível ou em Alerta.
+                                        Os ambientes podem estar Disponível,
+                                        Indisponível ou em Alerta.
                                     </p>
                                 </>
                             }
@@ -95,11 +114,16 @@ export default function Dashboard() {
                             tooltipContent={
                                 <>
                                     <p className="mb-4">
-                                        A saúde de servidores e workloads apontam o estado de funcionamento, desempenho e
-                                        estabilidade dos recursos computacionais que suportam aplicações e serviços de um sistema.
+                                        A saúde de servidores e workloads
+                                        apontam o estado de funcionamento,
+                                        desempenho e estabilidade dos recursos
+                                        computacionais que suportam aplicações e
+                                        serviços de um sistema.
                                     </p>
                                     <p>
-                                        O objetivo é garantir que os sistemas estejam disponíveis, performando bem e livres de falhas críticas.
+                                        O objetivo é garantir que os sistemas
+                                        estejam disponíveis, performando bem e
+                                        livres de falhas críticas.
                                     </p>
                                 </>
                             }
@@ -123,18 +147,23 @@ export default function Dashboard() {
                             tooltipContent={
                                 <>
                                     <p className="mb-4">
-                                        Essa seção acompanha a comunicação do sistema com
-                                        os bancos de dados e informações das aplicações.
+                                        Essa seção acompanha a comunicação do
+                                        sistema com os bancos de dados e
+                                        informações das aplicações.
                                     </p>
                                     <p>
-                                        Visa garantir que o banco esteja funcionando bem,
-                                        acessível e respondendo corretamente às consultas
-                                        das aplicações.
+                                        Visa garantir que o banco esteja
+                                        funcionando bem, acessível e respondendo
+                                        corretamente às consultas das
+                                        aplicações.
                                     </p>
                                 </>
                             }
                         >
-                            <DatabaseStatusCard systemName={projectName} className="bg-[#F5F5F5] p-3" />
+                            <DatabaseStatusCard
+                                systemName={projectName}
+                                className="bg-[#F5F5F5] p-3"
+                            />
                         </CardWrapperInfoAmbientes>
                     </div>
 
@@ -143,56 +172,94 @@ export default function Dashboard() {
                         title="Bugs"
                         tooltip={
                             <p>
-                                Ao final da página será possível visualizar o registro dos bugs e
-                                correções necessárias para o sistema, suas tratativas e andamento para
+                                Ao final da página será possível visualizar o
+                                registro dos bugs e correções necessárias para o
+                                sistema, suas tratativas e andamento para
                                 resolução.
                             </p>
                         }
                     >
-                        <AzureDevOpsBacklog className="p-[2px]" project={projectName} />
+                        <AzureDevOpsBacklog
+                            className="p-[2px]"
+                            project={projectName}
+                        />
                     </FullWidthSection>
                 </TabsContent>
 
                 <TabsContent value="analytics">
                     <div className="grid grid-cols-3 gap-4 mb-4">
-                        <ActiveUsersCard systemName={projectName} period={activePeriod} />
-                        <AverageSessionCard systemName={projectName} period={activePeriod} />
-                        <PeakUsageTodayCard systemName={projectName} period={activePeriod} />
+                        <ActiveUsersCard
+                            systemName={projectName}
+                            period={activePeriod}
+                        />
+                        <AverageSessionCard
+                            systemName={projectName}
+                            period={activePeriod}
+                        />
+                        <PeakUsageTodayCard
+                            systemName={projectName}
+                            period={activePeriod}
+                        />
                     </div>
                     <div className="grid grid-cols-4 gap-4 mb-4">
-                        <UsersByPageCard systemName={projectName} period={activePeriod} className="col-span-2" />
-                        <DeviceDistributionCard systemName={projectName} period={activePeriod} className="col-span-2" />
+                        <UsersByPageCard
+                            systemName={projectName}
+                            period={activePeriod}
+                            className="col-span-2"
+                        />
+                        <DeviceDistributionCard
+                            systemName={projectName}
+                            period={activePeriod}
+                            className="col-span-2"
+                        />
                     </div>
                     <FullWidthSection
                         title="Horários de pico"
                         tooltip={
                             <p>
-                                Essa seção mostra os horários com maior volume de acessos ao sistema,
-                                permitindo identificar os picos de uso ao longo do dia.
+                                Essa seção mostra os horários com maior volume
+                                de acessos ao sistema, permitindo identificar os
+                                picos de uso ao longo do dia.
                             </p>
                         }
                     >
-                        <PeakHoursChart systemName={projectName} period={activePeriod} className="p-[2px]" />
+                        <PeakHoursChart
+                            systemName={projectName}
+                            period={activePeriod}
+                            className="p-[2px]"
+                        />
                     </FullWidthSection>
                 </TabsContent>
 
                 <TabsContent value="saude-deploy">
-                    <EnvironmentHeader value={deployEnvironment} onChange={setDeployEnvironment} />
+                    <EnvironmentHeader
+                        value={deployEnvironment}
+                        onChange={setDeployEnvironment}
+                    />
                     <div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-4">
-                        <div id="onboarding-lancamentos" className="lg:col-span-1">
+                        <div
+                            id="onboarding-lancamentos"
+                            className="lg:col-span-1"
+                        >
                             <JenkinsJob
                                 project={projectName}
                                 subprojects={jenkinsSubprojects}
                                 environment={deployEnvironment}
                             />
                         </div>
-                        <SonarQualityIndicatorsCard
-                            projectName={projectName}
-                            sonarProjectKey={activeProject?.sonarProjectKey}
-                            zabbixQueryJenkinsJob={activeProject?.zabbixQueryJenkinsJob}
-                            environment={deployEnvironment}
+                        <div
+                            id="onboarding-sonar-quality"
                             className="lg:col-span-3"
-                        />
+                        >
+                            <SonarQualityIndicatorsCard
+                                projectName={projectName}
+                                sonarProjectKey={activeProject?.sonarProjectKey}
+                                zabbixQueryJenkinsJob={
+                                    activeProject?.zabbixQueryJenkinsJob
+                                }
+                                environment={deployEnvironment}
+                            />
+                        </div>
                     </div>
                 </TabsContent>
             </Tabs>

--- a/src/components/dashboard/DeployHealth/EnvironmentHeader.tsx
+++ b/src/components/dashboard/DeployHealth/EnvironmentHeader.tsx
@@ -1,51 +1,68 @@
 "use client";
 
-import { useMemo, useState } from "react";
 import { cn } from "@/lib/utils";
 import {
-  DEPLOY_ENVIRONMENTS,
-  type DeployEnvironment,
+    DEPLOY_ENVIRONMENTS,
+    type DeployEnvironment,
 } from "@/types/deployEnvironment";
+import { useMemo, useState } from "react";
 import EnvironmentSwitcher from "./EnvironmentSwitcher";
 
 type Props = {
-  readonly defaultEnvironment?: DeployEnvironment;
-  readonly value?: DeployEnvironment;
-  readonly onChange?: (next: DeployEnvironment) => void;
-  readonly className?: string;
+    readonly defaultEnvironment?: DeployEnvironment;
+    readonly value?: DeployEnvironment;
+    readonly onChange?: (next: DeployEnvironment) => void;
+    readonly className?: string;
 };
 
 export default function EnvironmentHeader({
-  defaultEnvironment = "producao",
-  value,
-  onChange,
-  className,
+    defaultEnvironment = "producao",
+    value,
+    onChange,
+    className,
 }: Props) {
-  const [internalValue, setInternalValue] = useState<DeployEnvironment>(defaultEnvironment);
-  const selected = value ?? internalValue;
+    const [internalValue, setInternalValue] =
+        useState<DeployEnvironment>(defaultEnvironment);
+    const selected = value ?? internalValue;
 
-  const current = useMemo(
-    () =>
-      DEPLOY_ENVIRONMENTS.find((env) => env.value === selected) ?? DEPLOY_ENVIRONMENTS[0],
-    [selected],
-  );
+    const current = useMemo(
+        () =>
+            DEPLOY_ENVIRONMENTS.find((env) => env.value === selected) ??
+            DEPLOY_ENVIRONMENTS[0],
+        [selected],
+    );
 
-  const handleChange = (next: DeployEnvironment) => {
-    if (value === undefined) {
-      setInternalValue(next);
-    }
-    onChange?.(next);
-  };
+    const handleChange = (next: DeployEnvironment) => {
+        if (value === undefined) {
+            setInternalValue(next);
+        }
+        onChange?.(next);
+    };
 
-  return (
-    <div className={cn("flex items-center justify-between px-6 py-4", className)}>
-      <div className="flex items-center gap-3">
-        <span className={cn("h-2.5 w-2.5 rounded-full", current.dotClassName)} aria-hidden />
-        <h3 className="text-base font-bold text-[#111827]">
-          {current.label} - {current.branch}
-        </h3>
-      </div>
-      <EnvironmentSwitcher value={selected} onChange={handleChange} />
-    </div>
-  );
+    return (
+        <div
+            className={cn(
+                "flex items-center justify-between px-6 py-4",
+                className,
+            )}
+        >
+            <div className="flex items-center gap-3">
+                <span
+                    className={cn(
+                        "h-2.5 w-2.5 rounded-full",
+                        current.dotClassName,
+                    )}
+                    aria-hidden
+                />
+                <h3 className="text-base font-bold text-[#111827]">
+                    {current.label} - {current.branch}
+                </h3>
+            </div>
+            <EnvironmentSwitcher
+                id="onboarding-environment-switcher"
+                value={selected}
+                onChange={handleChange}
+            />
+        </div>
+    );
 }

--- a/src/components/dashboard/DeployHealth/EnvironmentSwitcher.tsx
+++ b/src/components/dashboard/DeployHealth/EnvironmentSwitcher.tsx
@@ -1,56 +1,65 @@
 import { cn } from "@/lib/utils";
 import {
-  DEPLOY_ENVIRONMENTS,
-  type DeployEnvironment,
+    DEPLOY_ENVIRONMENTS,
+    type DeployEnvironment,
 } from "@/types/deployEnvironment";
 
 type Props = {
-  readonly value: DeployEnvironment;
-  readonly onChange: (next: DeployEnvironment) => void;
-  readonly className?: string;
-  readonly name?: string;
+    readonly value: DeployEnvironment;
+    readonly onChange: (next: DeployEnvironment) => void;
+    readonly className?: string;
+    readonly name?: string;
+    readonly id?: string;
 };
 
 export default function EnvironmentSwitcher({
-  value,
-  onChange,
-  className,
-  name = "deploy-environment",
+    value,
+    onChange,
+    className,
+    name = "deploy-environment",
+    id,
 }: Props) {
-  return (
-    <fieldset
-      className={cn(
-        "inline-flex items-stretch overflow-hidden rounded-lg border border-[#1E3A8A] bg-white",
-        className,
-      )}
-    >
-      <legend className="sr-only">Selecionar ambiente</legend>
-      {DEPLOY_ENVIRONMENTS.map((env, index) => {
-        const isSelected = env.value === value;
-        return (
-          <label
-            key={env.value}
+    return (
+        <fieldset
+            id={id}
             className={cn(
-              "inline-flex cursor-pointer items-center gap-2 px-6 py-2 text-sm font-bold transition-colors focus-within:ring-2 focus-within:ring-[#2563EB] focus-within:ring-inset",
-              index > 0 && "border-l border-[#1E3A8A]",
-              isSelected
-                ? "bg-[#1E3A8A] text-white"
-                : "bg-white text-[#1E3A8A] hover:bg-gray-50",
+                "inline-flex items-stretch overflow-hidden rounded-lg border border-[#1E3A8A] bg-white",
+                className,
             )}
-          >
-            <input
-              type="radio"
-              name={name}
-              value={env.value}
-              checked={isSelected}
-              onChange={() => onChange(env.value)}
-              className="sr-only"
-            />
-            <span className={cn("h-2.5 w-2.5 rounded-full", env.dotClassName)} aria-hidden />
-            {env.label}
-          </label>
-        );
-      })}
-    </fieldset>
-  );
+        >
+            <legend className="sr-only">Selecionar ambiente</legend>
+            {DEPLOY_ENVIRONMENTS.map((env, index) => {
+                const isSelected = env.value === value;
+                return (
+                    <label
+                        key={env.value}
+                        className={cn(
+                            "inline-flex cursor-pointer items-center gap-2 px-6 py-2 text-sm font-bold transition-colors focus-within:ring-2 focus-within:ring-[#2563EB] focus-within:ring-inset",
+                            index > 0 && "border-l border-[#1E3A8A]",
+                            isSelected
+                                ? "bg-[#1E3A8A] text-white"
+                                : "bg-white text-[#1E3A8A] hover:bg-gray-50",
+                        )}
+                    >
+                        <input
+                            type="radio"
+                            name={name}
+                            value={env.value}
+                            checked={isSelected}
+                            onChange={() => onChange(env.value)}
+                            className="sr-only"
+                        />
+                        <span
+                            className={cn(
+                                "h-2.5 w-2.5 rounded-full",
+                                env.dotClassName,
+                            )}
+                            aria-hidden
+                        />
+                        {env.label}
+                    </label>
+                );
+            })}
+        </fieldset>
+    );
 }

--- a/src/components/dashboard/Onboarding/DeployHealthTourOverlay.test.tsx
+++ b/src/components/dashboard/Onboarding/DeployHealthTourOverlay.test.tsx
@@ -1,0 +1,391 @@
+﻿/* @vitest-environment jsdom */
+import * as deployHealthHook from "@/hooks/useDeployHealthOnboarding";
+import {
+    DEPLOY_HEALTH_TOUR_STEPS,
+    useOnboardingStore,
+} from "@/states/onboarding";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DeployHealthTourOverlay } from "./DeployHealthTourOverlay";
+
+describe("<DeployHealthTourOverlay />", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        useOnboardingStore.setState({
+            isDeployTourActive: false,
+            deployTourStepIndex: 0,
+        });
+        localStorage.clear();
+
+        DEPLOY_HEALTH_TOUR_STEPS.forEach((step, index) => {
+            const el = document.createElement("div");
+            el.id = step.targetId;
+            el.style.position = "absolute";
+            el.style.top = `${100 + index * 200}px`;
+            el.style.left = "100px";
+            el.style.width = "300px";
+            el.style.height = "50px";
+            document.body.appendChild(el);
+        });
+    });
+
+    afterEach(() => {
+        DEPLOY_HEALTH_TOUR_STEPS.forEach((step) => {
+            const el = document.getElementById(step.targetId);
+            if (el) document.body.removeChild(el);
+        });
+    });
+
+    it("não deve renderizar quando isDeployTourActive é false", () => {
+        useOnboardingStore.setState({ isDeployTourActive: false });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.queryByText(DEPLOY_HEALTH_TOUR_STEPS[0].title),
+        ).not.toBeInTheDocument();
+    });
+
+    it("não deve renderizar quando currentStep é undefined com tour ativo", () => {
+        vi.spyOn(deployHealthHook, "useDeployHealthOnboarding").mockReturnValue(
+            {
+                isDeployTourActive: true,
+                currentStep: undefined,
+                deployTourStepIndex: 0,
+                totalSteps: 3,
+                triggerDeployTour: vi.fn(),
+                nextDeployStep: vi.fn(),
+                closeDeployTour: vi.fn(),
+            } as unknown as ReturnType<
+                typeof deployHealthHook.useDeployHealthOnboarding
+            >,
+        );
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.queryByText(DEPLOY_HEALTH_TOUR_STEPS[0].title),
+        ).not.toBeInTheDocument();
+    });
+
+    it("deve renderizar quando isDeployTourActive é true", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(DEPLOY_HEALTH_TOUR_STEPS[0].title),
+        ).toBeInTheDocument();
+    });
+
+    it("não deve renderizar quando elemento alvo não existe no DOM (targetRect fica null)", () => {
+        DEPLOY_HEALTH_TOUR_STEPS.forEach((step) => {
+            const el = document.getElementById(step.targetId);
+            if (el) document.body.removeChild(el);
+        });
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.queryByText(DEPLOY_HEALTH_TOUR_STEPS[0].title),
+        ).not.toBeInTheDocument();
+    });
+
+    it("deve exibir o título do step atual", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(DEPLOY_HEALTH_TOUR_STEPS[0].title),
+        ).toBeInTheDocument();
+    });
+
+    it("deve exibir a descrição do step atual", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(DEPLOY_HEALTH_TOUR_STEPS[0].description),
+        ).toBeInTheDocument();
+    });
+
+    it("deve exibir o contador de steps", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(`1/${DEPLOY_HEALTH_TOUR_STEPS.length}`),
+        ).toBeInTheDocument();
+    });
+
+    it("deve exibir 'Próximo' quando não é o último step", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByRole("button", { name: /próximo/i }),
+        ).toBeInTheDocument();
+    });
+
+    it("deve exibir 'Concluir' no último step", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: DEPLOY_HEALTH_TOUR_STEPS.length - 1,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByRole("button", { name: /concluir/i }),
+        ).toBeInTheDocument();
+    });
+
+    it("atualiza o contador ao mudar de step", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        const { rerender } = render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(`1/${DEPLOY_HEALTH_TOUR_STEPS.length}`),
+        ).toBeInTheDocument();
+
+        act(() => {
+            useOnboardingStore.setState({ deployTourStepIndex: 1 });
+        });
+        rerender(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(`2/${DEPLOY_HEALTH_TOUR_STEPS.length}`),
+        ).toBeInTheDocument();
+    });
+
+    it("deve avançar para o próximo step ao clicar em Próximo", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        fireEvent.click(screen.getByRole("button", { name: /próximo/i }));
+        expect(useOnboardingStore.getState().deployTourStepIndex).toBe(1);
+    });
+
+    it("deve fechar o tour ao clicar em Fechar e persistir no localStorage", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        fireEvent.click(screen.getByRole("button", { name: "Fechar" }));
+        expect(useOnboardingStore.getState().isDeployTourActive).toBe(false);
+        expect(
+            localStorage.getItem("autosservico-deploy-onboarding-completed"),
+        ).toBe("true");
+    });
+
+    it("deve fechar o tour ao clicar no ícone X", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        fireEvent.click(screen.getByLabelText(/fechar tour/i));
+        expect(useOnboardingStore.getState().isDeployTourActive).toBe(false);
+    });
+
+    it("renderiza spotlight com box-shadow quando spotlightBorderRadius está definido (step 0)", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        const spotlightDiv = document.querySelector('[style*="box-shadow"]');
+        expect(spotlightDiv).toBeInTheDocument();
+    });
+
+    it("renderiza 4 divs de overlay quando spotlightBorderRadius não está definido", () => {
+        vi.spyOn(deployHealthHook, "useDeployHealthOnboarding").mockReturnValue(
+            {
+                isDeployTourActive: true,
+                currentStep: {
+                    id: "test-no-radius",
+                    targetId: "onboarding-lancamentos",
+                    title: "Step Sem Radius",
+                    description: "Sem border radius",
+                    placement: "right",
+                },
+                deployTourStepIndex: 1,
+                totalSteps: 3,
+                triggerDeployTour: vi.fn(),
+                nextDeployStep: vi.fn(),
+                closeDeployTour: vi.fn(),
+            },
+        );
+        render(<DeployHealthTourOverlay />);
+        const overlayDivs = document.querySelectorAll(".bg-black\\/50");
+        expect(overlayDivs.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it("renderiza seta bottom quando placement é 'bottom' (step 0)", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(DEPLOY_HEALTH_TOUR_STEPS[0].title),
+        ).toBeInTheDocument();
+    });
+
+    it("renderiza seta right quando placement é 'right' (step 1)", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 1,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(DEPLOY_HEALTH_TOUR_STEPS[1].title),
+        ).toBeInTheDocument();
+    });
+
+    it("renderiza seta top quando placement é 'top' (step 2)", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 2,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(DEPLOY_HEALTH_TOUR_STEPS[2].title),
+        ).toBeInTheDocument();
+    });
+
+    it("renderiza seta left quando placement é 'left'", () => {
+        vi.spyOn(deployHealthHook, "useDeployHealthOnboarding").mockReturnValue(
+            {
+                isDeployTourActive: true,
+                currentStep: {
+                    id: "test-left",
+                    targetId: "onboarding-lancamentos",
+                    title: "Step Left",
+                    description: "Tooltip à esquerda",
+                    placement: "left",
+                },
+                deployTourStepIndex: 0,
+                totalSteps: 3,
+                triggerDeployTour: vi.fn(),
+                nextDeployStep: vi.fn(),
+                closeDeployTour: vi.fn(),
+            },
+        );
+        render(<DeployHealthTourOverlay />);
+        expect(screen.getByText("Step Left")).toBeInTheDocument();
+    });
+
+    it("renderiza seta left centralizada com centered=true", () => {
+        vi.spyOn(deployHealthHook, "useDeployHealthOnboarding").mockReturnValue(
+            {
+                isDeployTourActive: true,
+                currentStep: {
+                    id: "test-centered-left",
+                    targetId: "onboarding-lancamentos",
+                    title: "Step Centered Left",
+                    description: "Tooltip centralizado à esquerda",
+                    placement: "left",
+                    centered: true,
+                },
+                deployTourStepIndex: 0,
+                totalSteps: 3,
+                triggerDeployTour: vi.fn(),
+                nextDeployStep: vi.fn(),
+                closeDeployTour: vi.fn(),
+            },
+        );
+        render(<DeployHealthTourOverlay />);
+        expect(screen.getByText("Step Centered Left")).toBeInTheDocument();
+    });
+
+    it("renderiza seta right centralizada com centered=true", () => {
+        vi.spyOn(deployHealthHook, "useDeployHealthOnboarding").mockReturnValue(
+            {
+                isDeployTourActive: true,
+                currentStep: {
+                    id: "test-centered-right",
+                    targetId: "onboarding-lancamentos",
+                    title: "Step Centered Right",
+                    description: "Tooltip centralizado à direita",
+                    placement: "right",
+                    centered: true,
+                },
+                deployTourStepIndex: 1,
+                totalSteps: 3,
+                triggerDeployTour: vi.fn(),
+                nextDeployStep: vi.fn(),
+                closeDeployTour: vi.fn(),
+            },
+        );
+        render(<DeployHealthTourOverlay />);
+        expect(screen.getByText("Step Centered Right")).toBeInTheDocument();
+    });
+
+    it("clampeia tooltip para a direita quando ultrapassa a borda da janela", () => {
+        const el = document.getElementById(
+            DEPLOY_HEALTH_TOUR_STEPS[1].targetId,
+        );
+        if (el) {
+            el.getBoundingClientRect = vi.fn().mockReturnValue({
+                top: 100,
+                left: 900,
+                right: 1000,
+                bottom: 150,
+                width: 100,
+                height: 50,
+                x: 900,
+                y: 100,
+                toJSON: () => ({}),
+            });
+        }
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 1,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(
+            screen.getByText(DEPLOY_HEALTH_TOUR_STEPS[1].title),
+        ).toBeInTheDocument();
+    });
+
+    it("adiciona event listeners de resize e scroll quando tour está ativo", () => {
+        const addSpy = vi.spyOn(window, "addEventListener");
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        render(<DeployHealthTourOverlay />);
+        expect(addSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+        expect(addSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
+    });
+
+    it("remove event listeners ao desmontar o componente", () => {
+        const removeSpy = vi.spyOn(window, "removeEventListener");
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: 0,
+        });
+        const { unmount } = render(<DeployHealthTourOverlay />);
+        unmount();
+        expect(removeSpy).toHaveBeenCalledWith("resize", expect.any(Function));
+        expect(removeSpy).toHaveBeenCalledWith("scroll", expect.any(Function));
+    });
+
+    it("não adiciona event listeners quando tour está inativo", () => {
+        const addSpy = vi.spyOn(window, "addEventListener");
+        useOnboardingStore.setState({ isDeployTourActive: false });
+        render(<DeployHealthTourOverlay />);
+        expect(addSpy).not.toHaveBeenCalledWith("resize", expect.any(Function));
+        expect(addSpy).not.toHaveBeenCalledWith("scroll", expect.any(Function));
+    });
+});

--- a/src/components/dashboard/Onboarding/DeployHealthTourOverlay.test.tsx
+++ b/src/components/dashboard/Onboarding/DeployHealthTourOverlay.test.tsx
@@ -134,15 +134,18 @@ describe("<DeployHealthTourOverlay />", () => {
         ).toBeInTheDocument();
     });
 
-    it("deve exibir 'Concluir' no último step", () => {
+    it("deve exibir apenas o botão 'Fechar' no último step", () => {
         useOnboardingStore.setState({
             isDeployTourActive: true,
             deployTourStepIndex: DEPLOY_HEALTH_TOUR_STEPS.length - 1,
         });
         render(<DeployHealthTourOverlay />);
         expect(
-            screen.getByRole("button", { name: /concluir/i }),
+            screen.getByRole("button", { name: "Fechar" }),
         ).toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: /próximo/i }),
+        ).not.toBeInTheDocument();
     });
 
     it("atualiza o contador ao mudar de step", () => {

--- a/src/components/dashboard/Onboarding/DeployHealthTourOverlay.tsx
+++ b/src/components/dashboard/Onboarding/DeployHealthTourOverlay.tsx
@@ -261,15 +261,15 @@ export function DeployHealthTourOverlay() {
                         >
                             Fechar
                         </Button>
-                        <Button
-                            size="sm"
-                            onClick={nextDeployStep}
-                            className="px-4 bg-[#1E3A8A] hover:bg-[#1E3A8A]/90"
-                        >
-                            {deployTourStepIndex === totalSteps - 1
-                                ? "Concluir"
-                                : "Próximo"}
-                        </Button>
+                        {deployTourStepIndex < totalSteps - 1 && (
+                            <Button
+                                size="sm"
+                                onClick={nextDeployStep}
+                                className="px-4 bg-[#1E3A8A] hover:bg-[#1E3A8A]/90"
+                            >
+                                Próximo
+                            </Button>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/components/dashboard/Onboarding/DeployHealthTourOverlay.tsx
+++ b/src/components/dashboard/Onboarding/DeployHealthTourOverlay.tsx
@@ -1,0 +1,279 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useDeployHealthOnboarding } from "@/hooks/useDeployHealthOnboarding";
+import { cn } from "@/lib/utils";
+import { X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+type TargetRect = {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+};
+
+export function DeployHealthTourOverlay() {
+    const {
+        isDeployTourActive,
+        currentStep,
+        deployTourStepIndex,
+        totalSteps,
+        nextDeployStep,
+        closeDeployTour,
+    } = useDeployHealthOnboarding();
+
+    const [targetRect, setTargetRect] = useState<TargetRect | null>(null);
+    const [tooltipPosition, setTooltipPosition] = useState({ top: 0, left: 0 });
+
+    const updateTargetPosition = useCallback(() => {
+        if (!currentStep) return;
+
+        const element = document.getElementById(currentStep.targetId);
+        if (element) {
+            const rect = element.getBoundingClientRect();
+            const padding = currentStep.spotlightPadding ?? 12;
+            const paddingY = currentStep.spotlightPaddingY ?? padding;
+
+            const width =
+                currentStep.spotlightWidth ?? rect.width + padding * 2;
+            const height =
+                currentStep.spotlightHeight ?? rect.height + paddingY * 2;
+
+            setTargetRect({
+                top: rect.top,
+                left: rect.left,
+                width,
+                height,
+            });
+
+            const spotlightTop = rect.top - paddingY;
+            const spotlightLeft = rect.left - padding;
+            const spotlightRight = rect.left + width - padding;
+            const spotlightBottom = rect.top + height - paddingY;
+
+            const tooltipWidth = 320;
+            const tooltipHeight = 180;
+            const gap = 16;
+
+            let top = spotlightTop;
+            let left = spotlightRight + gap;
+
+            if (currentStep.placement === "left") {
+                left = spotlightLeft - tooltipWidth - gap;
+            } else if (currentStep.placement === "top") {
+                top = spotlightTop - tooltipHeight - gap;
+                left = spotlightLeft;
+            } else if (currentStep.placement === "bottom") {
+                top = spotlightBottom + gap;
+                left = spotlightLeft + 35;
+            }
+
+            if (
+                currentStep.centered &&
+                (currentStep.placement === "right" ||
+                    currentStep.placement === "left")
+            ) {
+                top = spotlightTop + height / 2 - tooltipHeight / 2;
+            }
+
+            if (left + tooltipWidth > window.innerWidth - 20) {
+                left = window.innerWidth - tooltipWidth - 20;
+            }
+            if (left < 20) {
+                left = 20;
+            }
+
+            setTooltipPosition({ top, left });
+        }
+    }, [currentStep]);
+
+    useEffect(() => {
+        if (!isDeployTourActive) return;
+
+        updateTargetPosition();
+
+        window.addEventListener("resize", updateTargetPosition);
+        window.addEventListener("scroll", updateTargetPosition);
+
+        return () => {
+            window.removeEventListener("resize", updateTargetPosition);
+            window.removeEventListener("scroll", updateTargetPosition);
+        };
+    }, [isDeployTourActive, currentStep, updateTargetPosition]);
+
+    if (!isDeployTourActive || !currentStep || !targetRect) return null;
+
+    const padding = currentStep.spotlightPadding ?? 12;
+    const paddingY = currentStep.spotlightPaddingY ?? padding;
+    const spotlightTop = targetRect.top - paddingY;
+    const spotlightLeft = targetRect.left - padding;
+    const spotlightWidth = targetRect.width;
+    const spotlightHeight = targetRect.height;
+
+    return createPortal(
+        <div className="fixed inset-0 z-[100]">
+            {currentStep.spotlightBorderRadius ? (
+                <div
+                    className="absolute pointer-events-none"
+                    style={{
+                        top: spotlightTop,
+                        left: spotlightLeft,
+                        width: spotlightWidth,
+                        height: spotlightHeight,
+                        borderRadius: currentStep.spotlightBorderRadius,
+                        boxShadow: "0 0 0 9999px rgba(0, 0, 0, 0.5)",
+                    }}
+                />
+            ) : (
+                <>
+                    {/* Overlay - Top */}
+                    <div
+                        className="absolute left-0 right-0 top-0 bg-black/50"
+                        style={{ height: spotlightTop }}
+                    />
+                    {/* Overlay - Bottom */}
+                    <div
+                        className="absolute left-0 right-0 bottom-0 bg-black/50"
+                        style={{ top: spotlightTop + spotlightHeight }}
+                    />
+                    {/* Overlay - Left */}
+                    <div
+                        className="absolute left-0 bg-black/50"
+                        style={{
+                            top: spotlightTop,
+                            width: spotlightLeft,
+                            height: spotlightHeight,
+                        }}
+                    />
+                    {/* Overlay - Right */}
+                    <div
+                        className="absolute right-0 bg-black/50"
+                        style={{
+                            top: spotlightTop,
+                            left: spotlightLeft + spotlightWidth,
+                            height: spotlightHeight,
+                        }}
+                    />
+                </>
+            )}
+
+            {/* Tooltip */}
+            <div
+                className={cn(
+                    "absolute bg-white rounded-lg shadow-xl p-5 w-[320px]",
+                    "animate-in fade-in-0 zoom-in-95 duration-200",
+                )}
+                style={{ top: tooltipPosition.top, left: tooltipPosition.left }}
+            >
+                {/* Arrow - right */}
+                {currentStep.placement === "right" && (
+                    <div
+                        className="absolute w-4 h-8 overflow-hidden"
+                        style={{
+                            left: -16,
+                            top: currentStep.centered ? "50%" : 16,
+                            transform: currentStep.centered
+                                ? "translateY(-50%)"
+                                : undefined,
+                        }}
+                    >
+                        <div
+                            className="absolute w-4 h-4 bg-white rotate-45 shadow-xl"
+                            style={{ left: 8, top: 8 }}
+                        />
+                    </div>
+                )}
+                {/* Arrow - bottom */}
+                {currentStep.placement === "bottom" && (
+                    <div
+                        className="absolute h-4 w-8 overflow-hidden"
+                        style={{ top: -16, left: 16 }}
+                    >
+                        <div
+                            className="absolute w-4 h-4 bg-white rotate-45 shadow-xl"
+                            style={{ top: 8, left: 8 }}
+                        />
+                    </div>
+                )}
+                {/* Arrow - left */}
+                {currentStep.placement === "left" && (
+                    <div
+                        className="absolute w-4 h-8 overflow-hidden"
+                        style={{
+                            right: -16,
+                            top: currentStep.centered ? "50%" : 16,
+                            transform: currentStep.centered
+                                ? "translateY(-50%)"
+                                : undefined,
+                        }}
+                    >
+                        <div
+                            className="absolute w-4 h-4 bg-white rotate-45 shadow-xl"
+                            style={{ left: -8, top: 8 }}
+                        />
+                    </div>
+                )}
+                {/* Arrow - top */}
+                {currentStep.placement === "top" && (
+                    <div
+                        className="absolute h-4 w-8 overflow-hidden"
+                        style={{ bottom: -16, left: 16 }}
+                    >
+                        <div
+                            className="absolute w-4 h-4 bg-white rotate-45 shadow-xl"
+                            style={{ top: -8, left: 8 }}
+                        />
+                    </div>
+                )}
+
+                {/* Close button */}
+                <button
+                    onClick={closeDeployTour}
+                    className="absolute top-3 right-3 text-[#1E3A8A] hover:text-[#1E3A8A]/80 transition-colors"
+                    aria-label="Fechar tour"
+                >
+                    <div className="w-4 h-4 rounded-full border-[1.5px] border-[#1E3A8A] flex items-center justify-center">
+                        <X className="w-2.5 h-2.5" strokeWidth={2.5} />
+                    </div>
+                </button>
+
+                {/* Content */}
+                <h3 className="text-lg font-semibold text-[#1E3A8A] pr-6">
+                    {currentStep.title}
+                </h3>
+                <p className="mt-2 text-sm text-[#111827]">
+                    {currentStep.description}
+                </p>
+
+                {/* Footer */}
+                <div className="flex items-center justify-between mt-5">
+                    <span className="text-sm text-muted-foreground">
+                        {deployTourStepIndex + 1}/{totalSteps}
+                    </span>
+                    <div className="flex gap-2">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={closeDeployTour}
+                            className="px-4 border-[#1E3A8A] text-[#1E3A8A] hover:bg-[#1E3A8A]/10"
+                        >
+                            Fechar
+                        </Button>
+                        <Button
+                            size="sm"
+                            onClick={nextDeployStep}
+                            className="px-4 bg-[#1E3A8A] hover:bg-[#1E3A8A]/90"
+                        >
+                            {deployTourStepIndex === totalSteps - 1
+                                ? "Concluir"
+                                : "Próximo"}
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </div>,
+        document.body,
+    );
+}

--- a/src/components/dashboard/Onboarding/DeployHealthTourOverlay.tsx
+++ b/src/components/dashboard/Onboarding/DeployHealthTourOverlay.tsx
@@ -240,10 +240,10 @@ export function DeployHealthTourOverlay() {
                 </button>
 
                 {/* Content */}
-                <h3 className="text-lg font-semibold text-[#1E3A8A] pr-6">
+                <h3 className="text-sm font-bold text-[#111827] pr-6">
                     {currentStep.title}
                 </h3>
-                <p className="mt-2 text-sm text-[#111827]">
+                <p className="mt-2 text-sm font-normal text-[#111827]">
                     {currentStep.description}
                 </p>
 

--- a/src/hooks/useDeployHealthOnboarding.test.ts
+++ b/src/hooks/useDeployHealthOnboarding.test.ts
@@ -1,0 +1,204 @@
+/* @vitest-environment jsdom */
+import {
+    DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY,
+    DEPLOY_HEALTH_TOUR_STEPS,
+    useOnboardingStore,
+} from "@/states/onboarding";
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDeployHealthOnboarding } from "./useDeployHealthOnboarding";
+
+describe("useDeployHealthOnboarding", () => {
+    beforeEach(() => {
+        useOnboardingStore.setState({
+            isDeployTourActive: false,
+            deployTourStepIndex: 0,
+        });
+        localStorage.clear();
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    // ----------------------------
+    // Estado inicial
+    // ----------------------------
+
+    it("deve retornar o estado inicial corretamente", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        expect(result.current.isDeployTourActive).toBe(false);
+        expect(result.current.deployTourStepIndex).toBe(0);
+        expect(result.current.totalSteps).toBe(DEPLOY_HEALTH_TOUR_STEPS.length);
+        expect(result.current.currentStep).toEqual(DEPLOY_HEALTH_TOUR_STEPS[0]);
+    });
+
+    // ----------------------------
+    // triggerDeployTour
+    // ----------------------------
+
+    it("deve iniciar o tour quando o onboarding de deploy não foi completado", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        act(() => {
+            result.current.triggerDeployTour();
+        });
+
+        expect(result.current.isDeployTourActive).toBe(true);
+        expect(result.current.deployTourStepIndex).toBe(0);
+    });
+
+    it("não deve iniciar o tour em ambiente de servidor (window undefined)", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        vi.stubGlobal("window", undefined);
+
+        act(() => {
+            result.current.triggerDeployTour();
+        });
+
+        expect(result.current.isDeployTourActive).toBe(false);
+    });
+
+    it("não deve iniciar o tour quando o onboarding de deploy já foi completado", () => {
+        localStorage.setItem(DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY, "true");
+
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        act(() => {
+            result.current.triggerDeployTour();
+        });
+
+        expect(result.current.isDeployTourActive).toBe(false);
+    });
+
+    // ----------------------------
+    // Navegação — nextDeployStep
+    // ----------------------------
+
+    it("deve avançar para o próximo passo com nextDeployStep", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        act(() => {
+            result.current.triggerDeployTour();
+        });
+
+        act(() => {
+            result.current.nextDeployStep();
+        });
+
+        expect(result.current.deployTourStepIndex).toBe(1);
+        expect(result.current.currentStep).toEqual(DEPLOY_HEALTH_TOUR_STEPS[1]);
+    });
+
+    it("deve encerrar o tour e persistir no localStorage ao avançar do último passo", () => {
+        useOnboardingStore.setState({
+            isDeployTourActive: true,
+            deployTourStepIndex: DEPLOY_HEALTH_TOUR_STEPS.length - 1,
+        });
+
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        act(() => {
+            result.current.nextDeployStep();
+        });
+
+        expect(result.current.isDeployTourActive).toBe(false);
+        expect(result.current.deployTourStepIndex).toBe(0);
+        expect(localStorage.getItem(DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY)).toBe(
+            "true",
+        );
+    });
+
+    // ----------------------------
+    // Fechamento — closeDeployTour
+    // ----------------------------
+
+    it("deve encerrar o tour com closeDeployTour", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        act(() => {
+            result.current.triggerDeployTour();
+        });
+
+        expect(result.current.isDeployTourActive).toBe(true);
+
+        act(() => {
+            result.current.closeDeployTour();
+        });
+
+        expect(result.current.isDeployTourActive).toBe(false);
+    });
+
+    it("deve persistir no localStorage ao fechar o tour", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        act(() => {
+            result.current.triggerDeployTour();
+            result.current.closeDeployTour();
+        });
+
+        expect(localStorage.getItem(DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY)).toBe(
+            "true",
+        );
+    });
+
+    it("não deve reabrir o tour após fechar (persistência)", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        act(() => {
+            result.current.triggerDeployTour();
+            result.current.closeDeployTour();
+        });
+
+        act(() => {
+            result.current.triggerDeployTour();
+        });
+
+        expect(result.current.isDeployTourActive).toBe(false);
+    });
+
+    // ----------------------------
+    // Passos do tour
+    // ----------------------------
+
+    it("deve expor o total de passos correto", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        expect(result.current.totalSteps).toBe(3);
+    });
+
+    it("deve retornar o passo correto para cada índice", () => {
+        const { result } = renderHook(() => useDeployHealthOnboarding());
+
+        act(() => {
+            result.current.triggerDeployTour();
+        });
+
+        expect(result.current.currentStep.id).toBe(
+            "deploy-environment-switcher",
+        );
+        expect(result.current.currentStep.targetId).toBe(
+            "onboarding-environment-switcher",
+        );
+
+        act(() => {
+            result.current.nextDeployStep();
+        });
+
+        expect(result.current.currentStep.id).toBe("deploy-jenkins");
+        expect(result.current.currentStep.targetId).toBe(
+            "onboarding-lancamentos",
+        );
+
+        act(() => {
+            result.current.nextDeployStep();
+        });
+
+        expect(result.current.currentStep.id).toBe("deploy-sonar-quality");
+        expect(result.current.currentStep.targetId).toBe(
+            "onboarding-sonar-quality",
+        );
+    });
+});

--- a/src/hooks/useDeployHealthOnboarding.ts
+++ b/src/hooks/useDeployHealthOnboarding.ts
@@ -1,0 +1,39 @@
+"use client";
+import {
+    DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY,
+    DEPLOY_HEALTH_TOUR_STEPS,
+    useOnboardingStore,
+} from "@/states/onboarding";
+
+export function useDeployHealthOnboarding() {
+    const {
+        isDeployTourActive,
+        deployTourStepIndex,
+        startDeployTour,
+        nextDeployStep,
+        closeDeployTour,
+    } = useOnboardingStore();
+
+    const triggerDeployTour = () => {
+        if (typeof window === "undefined") return;
+        const hasCompleted = localStorage.getItem(
+            DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY,
+        );
+        if (!hasCompleted) {
+            startDeployTour();
+        }
+    };
+
+    const currentStep = DEPLOY_HEALTH_TOUR_STEPS[deployTourStepIndex];
+    const totalSteps = DEPLOY_HEALTH_TOUR_STEPS.length;
+
+    return {
+        isDeployTourActive,
+        deployTourStepIndex,
+        currentStep,
+        totalSteps,
+        triggerDeployTour,
+        nextDeployStep,
+        closeDeployTour,
+    };
+}

--- a/src/states/onboarding.ts
+++ b/src/states/onboarding.ts
@@ -8,6 +8,9 @@ export type TourStep = {
     placement: "top" | "bottom" | "left" | "right";
     spotlightWidth?: number;
     spotlightHeight?: number;
+    spotlightPadding?: number;
+    spotlightPaddingY?: number;
+    spotlightBorderRadius?: number;
     centered?: boolean;
 };
 
@@ -80,6 +83,8 @@ type OnboardingState = {
     hasCompletedOnboarding: boolean;
     isTourActive: boolean;
     currentStepIndex: number;
+    isDeployTourActive: boolean;
+    deployTourStepIndex: number;
 };
 
 type OnboardingActions = {
@@ -90,9 +95,46 @@ type OnboardingActions = {
     prevStep: () => void;
     closeTour: () => void;
     completeOnboarding: () => void;
+    startDeployTour: () => void;
+    nextDeployStep: () => void;
+    closeDeployTour: () => void;
 };
 
 export const ONBOARDING_STORAGE_KEY = "autosservico-onboarding-completed";
+export const DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY =
+    "autosservico-deploy-onboarding-completed";
+
+export const DEPLOY_HEALTH_TOUR_STEPS: TourStep[] = [
+    {
+        id: "deploy-environment-switcher",
+        targetId: "onboarding-environment-switcher",
+        title: "Seletor de ambiente",
+        description:
+            "Aqui você alterna entre os ambientes de Produção, Homologação e QA. Todos os dados correspondem ao ambiente selecionado.",
+        placement: "bottom",
+        spotlightPadding: 4,
+        spotlightPaddingY: 8,
+        spotlightBorderRadius: 8,
+    },
+    {
+        id: "deploy-jenkins",
+        targetId: "onboarding-lancamentos",
+        title: "Jenkins",
+        description:
+            "Nessa sessão, você vai acompanhar a saúde da esteira de desenvolvimento.",
+        placement: "right",
+        spotlightBorderRadius: 5,
+    },
+    {
+        id: "deploy-sonar-quality",
+        targetId: "onboarding-sonar-quality",
+        title: "Qualidade do código",
+        description:
+            "Visão geral da qualidade do código com métricas detalhadas e ratings de confiabilidade, segurança e manutenção.",
+        placement: "top",
+        spotlightBorderRadius: 6,
+    },
+];
 
 export const useOnboardingStore = create<OnboardingState & OnboardingActions>(
     (set, get) => ({
@@ -100,12 +142,18 @@ export const useOnboardingStore = create<OnboardingState & OnboardingActions>(
         hasCompletedOnboarding: false,
         isTourActive: false,
         currentStepIndex: 0,
+        isDeployTourActive: false,
+        deployTourStepIndex: 0,
 
         openWelcomeModal: () => set({ isWelcomeModalOpen: true }),
         closeWelcomeModal: () => set({ isWelcomeModalOpen: false }),
 
         startTour: () => {
-            set({ isWelcomeModalOpen: false, isTourActive: true, currentStepIndex: 0 });
+            set({
+                isWelcomeModalOpen: false,
+                isTourActive: true,
+                currentStepIndex: 0,
+            });
         },
 
         nextStep: () => {
@@ -130,7 +178,7 @@ export const useOnboardingStore = create<OnboardingState & OnboardingActions>(
         },
 
         completeOnboarding: () => {
-            if (typeof window !== "undefined") {
+            if (globalThis.window !== undefined) {
                 localStorage.setItem(ONBOARDING_STORAGE_KEY, "true");
             }
             set({
@@ -139,5 +187,34 @@ export const useOnboardingStore = create<OnboardingState & OnboardingActions>(
                 isTourActive: false,
             });
         },
-    })
+
+        startDeployTour: () => {
+            set({ isDeployTourActive: true, deployTourStepIndex: 0 });
+        },
+
+        nextDeployStep: () => {
+            const { deployTourStepIndex } = get();
+            if (deployTourStepIndex < DEPLOY_HEALTH_TOUR_STEPS.length - 1) {
+                set({ deployTourStepIndex: deployTourStepIndex + 1 });
+            } else {
+                if (globalThis.window !== undefined) {
+                    localStorage.setItem(
+                        DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY,
+                        "true",
+                    );
+                }
+                set({ isDeployTourActive: false, deployTourStepIndex: 0 });
+            }
+        },
+
+        closeDeployTour: () => {
+            if (globalThis.window !== undefined) {
+                localStorage.setItem(
+                    DEPLOY_HEALTH_ONBOARDING_STORAGE_KEY,
+                    "true",
+                );
+            }
+            set({ isDeployTourActive: false, deployTourStepIndex: 0 });
+        },
+    }),
 );


### PR DESCRIPTION
Historia: [AB#149248](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/149248) e [AB#149250](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/149250) e [AB#149249](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/149249)  e tarefa: [AB#149274](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/149274) e [AB#149275](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/149275) e [AB#149276](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/149276)

## Resumo
Implementa onboarding com Tour para a aba de saude do deploy no projeto, seguindo as regras de exibição unica, armazenamento no LocalStorage quando já foi visto o tour uma vez

## Como testar
- Abrir a aba Saúde do deploy no dashboard pela primeira vez, validando que o item `autosservico-deploy-onboarding-completed` não existe no LocalStorage
- Validar que ao concluir o tour o item é preenchido no LocalStorage como `true` e o tour não é exibido novamente