### PR TITLE
feat(perfil): adiciona tela de perfil do usuário

### DIFF
--- a/src/app/dashboard/layout.test.tsx
+++ b/src/app/dashboard/layout.test.tsx
@@ -12,6 +12,11 @@ vi.mock("@/lib/auth", () => ({
     auth: vi.fn(async () => mockSession),
 }));
 
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: vi.fn() }),
+    usePathname: () => "/dashboard",
+}));
+
 vi.mock("next-auth/react", () => ({
     __esModule: true,
     useSession: vi.fn(() => ({

--- a/src/app/perfil/PerfilShell.tsx
+++ b/src/app/perfil/PerfilShell.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+import type { Session } from "next-auth";
+import {
+    SidebarInset,
+    SidebarProvider,
+    SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { AppSidebar } from "@/components/dashboard/Sidebar/app-sidebar";
+import { SessionGuard } from "@/components/dashboard/SessionGuard";
+
+type PerfilShellProps = Readonly<{
+    children: React.ReactNode;
+    session: Session | null;
+}>;
+
+export function PerfilShell({ children, session }: PerfilShellProps) {
+    return (
+        <SessionProvider
+            session={session}
+            refetchInterval={5 * 60}
+            refetchOnWindowFocus={false}
+            refetchWhenOffline={false}
+        >
+            <SessionGuard>
+                <SidebarProvider>
+                    <AppSidebar />
+                    <SidebarInset>
+                        <SidebarTrigger className="md:hidden" />
+                        {children}
+                    </SidebarInset>
+                </SidebarProvider>
+            </SessionGuard>
+        </SessionProvider>
+    );
+}

--- a/src/app/perfil/layout.tsx
+++ b/src/app/perfil/layout.tsx
@@ -1,0 +1,11 @@
+import { auth } from "@/lib/auth";
+import { PerfilShell } from "./PerfilShell";
+
+export default async function PerfilLayout({
+    children,
+}: Readonly<{
+    children: React.ReactNode;
+}>) {
+    const session = await auth();
+    return <PerfilShell session={session}>{children}</PerfilShell>;
+}

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { HelpCircle } from "lucide-react";
+import { IdentityCard } from "@/components/perfil/IdentityCard";
+import { AccountActionsCard } from "@/components/perfil/AccountActionsCard";
+import { DadosPessoaisCard } from "@/components/perfil/DadosPessoaisCard";
+import { AreasAcessoCard } from "@/components/perfil/AreasAcessoCard";
+import { useAreasAcesso } from "@/hooks/useAreasAcesso";
+import { formatCpfMasked } from "@/lib/utils";
+
+const SITUACAO_USUARIO_ATIVO = 1;
+const EMPTY_FIELD = "—";
+
+export default function PerfilPage() {
+    const { data: session } = useSession();
+    const coordenadoriasAcesso = useAreasAcesso();
+
+    const nomeCompleto = session?.user?.name ?? EMPTY_FIELD;
+    const contaAtiva = session?.user?.situacaoUsuario === SITUACAO_USUARIO_ATIVO;
+    const cpf = formatCpfMasked(session?.user?.cpf) ?? EMPTY_FIELD;
+    const email = session?.user?.email ?? EMPTY_FIELD;
+
+    return (
+        <div className="px-6 py-6">
+            <header className="mb-6 flex items-center justify-between">
+                <h1 className="text-2xl font-bold text-foreground">Meu perfil</h1>
+                <button
+                    type="button"
+                    className="rounded-full p-1 text-sky-600 transition-colors hover:bg-sky-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+                    aria-label="Ajuda"
+                    data-testid="btn-ajuda-perfil"
+                >
+                    <HelpCircle className="size-6" aria-hidden="true" />
+                </button>
+            </header>
+
+            <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+                <aside className="flex flex-col gap-6 lg:col-span-1">
+                    <IdentityCard
+                        nomeCompleto={nomeCompleto}
+                        cargo={EMPTY_FIELD}
+                        coordenadoria={EMPTY_FIELD}
+                        contaAtiva={contaAtiva}
+                        ultimoAcesso={EMPTY_FIELD}
+                        tempoSessao={EMPTY_FIELD}
+                    />
+                    <AccountActionsCard />
+                </aside>
+
+                <div className="flex flex-col gap-6 lg:col-span-2">
+                    <DadosPessoaisCard
+                        nomeCompleto={nomeCompleto}
+                        cpf={cpf}
+                        email={email}
+                        cargo={EMPTY_FIELD}
+                        coordenadoria={EMPTY_FIELD}
+                    />
+                    <AreasAcessoCard coordenadorias={coordenadoriasAcesso} />
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -1,13 +1,12 @@
 "use client";
 
 import { useSession } from "next-auth/react";
-import { HelpCircle } from "lucide-react";
 import { IdentityCard } from "@/components/perfil/IdentityCard";
 import { AccountActionsCard } from "@/components/perfil/AccountActionsCard";
 import { DadosPessoaisCard } from "@/components/perfil/DadosPessoaisCard";
 import { AreasAcessoCard } from "@/components/perfil/AreasAcessoCard";
 import { useAreasAcesso } from "@/hooks/useAreasAcesso";
-import { formatCpfMasked } from "@/lib/utils";
+import { formatCpfMasked, formatUltimoAcesso } from "@/lib/utils";
 
 const SITUACAO_USUARIO_ATIVO = 1;
 const EMPTY_FIELD = "—";
@@ -20,30 +19,26 @@ export default function PerfilPage() {
     const contaAtiva = session?.user?.situacaoUsuario === SITUACAO_USUARIO_ATIVO;
     const cpf = formatCpfMasked(session?.user?.cpf) ?? EMPTY_FIELD;
     const email = session?.user?.email ?? EMPTY_FIELD;
+    const cargo = session?.user?.cargo ?? EMPTY_FIELD;
+    const coordenadoria = session?.user?.coordenadoria ?? EMPTY_FIELD;
+    const ultimoAcesso = formatUltimoAcesso(session?.user?.ultimo_acesso) ?? EMPTY_FIELD;
+    const tempoSessao = session?.user?.tempo_sessao ?? EMPTY_FIELD;
 
     return (
         <div className="px-6 py-6">
-            <header className="mb-6 flex items-center justify-between">
+            <header className="mb-6">
                 <h1 className="text-2xl font-bold text-foreground">Meu perfil</h1>
-                <button
-                    type="button"
-                    className="rounded-full p-1 text-sky-600 transition-colors hover:bg-sky-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
-                    aria-label="Ajuda"
-                    data-testid="btn-ajuda-perfil"
-                >
-                    <HelpCircle className="size-6" aria-hidden="true" />
-                </button>
             </header>
 
             <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
                 <aside className="flex flex-col gap-6 lg:col-span-1">
                     <IdentityCard
                         nomeCompleto={nomeCompleto}
-                        cargo={EMPTY_FIELD}
-                        coordenadoria={EMPTY_FIELD}
+                        cargo={cargo}
+                        coordenadoria={coordenadoria}
                         contaAtiva={contaAtiva}
-                        ultimoAcesso={EMPTY_FIELD}
-                        tempoSessao={EMPTY_FIELD}
+                        ultimoAcesso={ultimoAcesso}
+                        tempoSessao={tempoSessao}
                     />
                     <AccountActionsCard />
                 </aside>
@@ -53,8 +48,8 @@ export default function PerfilPage() {
                         nomeCompleto={nomeCompleto}
                         cpf={cpf}
                         email={email}
-                        cargo={EMPTY_FIELD}
-                        coordenadoria={EMPTY_FIELD}
+                        cargo={cargo}
+                        coordenadoria={coordenadoria}
                     />
                     <AreasAcessoCard coordenadorias={coordenadoriasAcesso} />
                 </div>

--- a/src/assets/icons/Perfil.tsx
+++ b/src/assets/icons/Perfil.tsx
@@ -1,0 +1,23 @@
+export default function Perfil(
+    props: Readonly<React.SVGProps<SVGSVGElement>>
+) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="28"
+            height="28"
+            viewBox="0 0 28 28"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            {...props}
+        >
+            <rect x="1" y="1" width="26" height="26" rx="4" ry="4" />
+            <circle cx="14" cy="12" r="3" />
+            <path d="M8.5 20.5c0-2.2 2.4-3.5 5.5-3.5s5.5 1.3 5.5 3.5" />
+        </svg>
+    );
+}

--- a/src/components/dashboard/Sidebar/app-sidebar.test.tsx
+++ b/src/components/dashboard/Sidebar/app-sidebar.test.tsx
@@ -77,6 +77,14 @@ vi.mock("@/assets/icons/SidebarCotic", () => ({
 }));
 
 
+// ✅ Mock do next/navigation (App Router)
+const mockRouterPush = vi.fn();
+let mockPathname = "/dashboard";
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: mockRouterPush }),
+    usePathname: () => mockPathname,
+}));
+
 // ✅ Mock do NextAuth/useSession com perfis válidos
 vi.mock("next-auth/react", () => {
     return {
@@ -113,6 +121,7 @@ const mockSetActiveItem = vi.fn();
 describe("<AppSidebar />", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        mockPathname = "/dashboard";
         (useDashboardStore as unknown as ViMock).mockImplementation(
             (selector) => {
                 return selector({
@@ -149,6 +158,20 @@ describe("<AppSidebar />", () => {
                 url: "#",
             })
         );
+    });
+
+    it("não navega ao clicar em um item quando já está no dashboard", () => {
+        mockPathname = "/dashboard";
+        renderWithSidebarProvider(<AppSidebar />);
+        fireEvent.click(screen.getByText("COPED"));
+        expect(mockRouterPush).not.toHaveBeenCalled();
+    });
+
+    it("navega para /dashboard ao clicar em um item fora do dashboard", () => {
+        mockPathname = "/perfil";
+        renderWithSidebarProvider(<AppSidebar />);
+        fireEvent.click(screen.getByText("COPED"));
+        expect(mockRouterPush).toHaveBeenCalledWith("/dashboard");
     });
 
     it("deve marcar o item como ativo quando activeItem.title corresponder", () => {

--- a/src/components/dashboard/Sidebar/app-sidebar.tsx
+++ b/src/components/dashboard/Sidebar/app-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useCallback, useEffect, useMemo } from "react";
+import { usePathname, useRouter } from "next/navigation";
 
 import {
     Sidebar,
@@ -21,10 +22,13 @@ import { COORDENADORIAS } from "./coordenadorias";
 
 import LogoutIcon from "@/assets/icons/Logout";
 import SignOutButton from "@/components/login/SignOutButton";
+import ProfileLink from "@/components/perfil/ProfileLink";
 
 
 export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
     const { open } = useSidebar();
+    const router = useRouter();
+    const pathname = usePathname();
 
     const activeItem = useDashboardStore((state) => state.activeItem);
     const setActiveItem = useDashboardStore((state) => state.setActiveItem);
@@ -49,7 +53,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
             url: item.url,
             icon: item.icon
         });
-    }, [setActiveItem]);
+        if (!pathname?.startsWith("/dashboard")) {
+            router.push("/dashboard");
+        }
+    }, [setActiveItem, pathname, router]);
 
     if (allowedItems.length === 0) {
         return (
@@ -60,6 +67,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                     </div>
                 </SidebarContent>
                 <SidebarFooter>
+                    <ProfileLink className="justify-end" />
                     <SignOutButton
                         variant="link"
                         className="[&_svg]:size-7 text-white no-underline hover:no-underline justify-end"
@@ -127,6 +135,10 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
                 </SidebarGroup>
             </SidebarContent>
             <SidebarFooter>
+                <ProfileLink
+                    className={open ? "justify-end" : "justify-center"}
+                    showLabel={open}
+                />
                 <SignOutButton
                     variant="link"
                     className={`${

--- a/src/components/perfil/AccountActionsCard.tsx
+++ b/src/components/perfil/AccountActionsCard.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { signOut } from "next-auth/react";
+import { LogOut } from "lucide-react";
+
+type AccountActionsCardProps = Readonly<{
+    onAlterarSenha?: () => void;
+}>;
+
+export function AccountActionsCard({ onAlterarSenha }: AccountActionsCardProps) {
+    const handleEncerrarSessao = () => {
+        signOut({ callbackUrl: "/" });
+    };
+
+    return (
+        <div className="flex flex-col items-center gap-4 rounded-2xl bg-white p-6 shadow-sm">
+            <button
+                type="button"
+                onClick={onAlterarSenha}
+                className="text-sm font-semibold text-sky-600 underline-offset-4 hover:underline focus:outline-none focus-visible:underline"
+                data-testid="btn-alterar-senha"
+            >
+                Alterar senha
+            </button>
+
+            <button
+                type="button"
+                onClick={handleEncerrarSessao}
+                className="inline-flex items-center gap-2 text-sm font-semibold text-red-600 underline-offset-4 hover:underline focus:outline-none focus-visible:underline"
+                data-testid="btn-encerrar-sessao"
+            >
+                <LogOut className="size-4" aria-hidden="true" />
+                Encerrar sessão
+            </button>
+        </div>
+    );
+}

--- a/src/components/perfil/AccountActionsCard.tsx
+++ b/src/components/perfil/AccountActionsCard.tsx
@@ -13,7 +13,7 @@ export function AccountActionsCard({ onAlterarSenha }: AccountActionsCardProps) 
     };
 
     return (
-        <div className="flex flex-col items-center gap-4 rounded-2xl bg-white p-6 shadow-sm">
+        <div className="flex flex-col items-center gap-4 rounded-lg bg-white p-6 shadow-lg">
             <button
                 type="button"
                 onClick={onAlterarSenha}

--- a/src/components/perfil/AreasAcessoCard.tsx
+++ b/src/components/perfil/AreasAcessoCard.tsx
@@ -33,7 +33,7 @@ function CoordenadoriaIcon({ sigla }: { readonly sigla: string }) {
 export function AreasAcessoCard({ coordenadorias }: AreasAcessoCardProps) {
     if (coordenadorias.length === 0) {
         return (
-            <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <section className="rounded-lg bg-white p-6 shadow-lg">
                 <h2 className="mb-4 text-base font-bold text-foreground">Áreas de acesso</h2>
                 <p className="text-sm text-muted-foreground">Nenhuma área de acesso disponível.</p>
             </section>
@@ -41,14 +41,14 @@ export function AreasAcessoCard({ coordenadorias }: AreasAcessoCardProps) {
     }
 
     return (
-        <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <section className="rounded-lg bg-white p-6 shadow-lg">
             <h2 className="mb-4 text-base font-bold text-foreground">Áreas de acesso</h2>
 
             <ul className="flex flex-col gap-3">
                 {coordenadorias.map((coord) => (
                     <li
                         key={coord.sigla}
-                        className="flex flex-col gap-3 rounded-lg bg-zinc-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                        className="flex flex-col gap-3 rounded-lg bg-[#F5F5F5] px-4 py-3 sm:flex-row sm:items-center sm:justify-between border-[#E5E7EB]"
                     >
                         <div className="flex items-center gap-3">
                             <div className="flex size-10 items-center justify-center rounded-lg bg-indigo-100">
@@ -64,7 +64,7 @@ export function AreasAcessoCard({ coordenadorias }: AreasAcessoCardProps) {
                             {coord.areas.map((area) => (
                                 <span
                                     key={`${coord.sigla}-${area}`}
-                                    className="inline-flex items-center rounded-md bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700"
+                                    className="inline-flex items-center rounded-md bg-[#E6EDFF] px-3 py-1 text-xs font-semibold text-[#1E3A8A]"
                                 >
                                     {area}
                                 </span>

--- a/src/components/perfil/AreasAcessoCard.tsx
+++ b/src/components/perfil/AreasAcessoCard.tsx
@@ -1,0 +1,78 @@
+import {
+    Globe,
+    MessageCircle,
+    Utensils,
+    Shield,
+    Users,
+    BookOpen,
+    ClipboardList,
+    Building2,
+    type LucideIcon,
+} from "lucide-react";
+import type { CoordenadoriaAcesso } from "@/types/coordenadoriaAcesso";
+
+const COORDENADORIA_ICONS: Record<string, LucideIcon> = {
+    ASCOM: MessageCircle,
+    CODAE: Utensils,
+    COPED: BookOpen,
+    COPLAN: ClipboardList,
+    COTIC: Globe,
+    COGEP: Users,
+    GIPE: Shield,
+};
+
+type AreasAcessoCardProps = Readonly<{
+    coordenadorias: CoordenadoriaAcesso[];
+}>;
+
+function CoordenadoriaIcon({ sigla }: { readonly sigla: string }) {
+    const Icon = COORDENADORIA_ICONS[sigla.toUpperCase()] ?? Building2;
+    return <Icon className="size-6 text-blue-900" strokeWidth={2} aria-hidden="true" />;
+}
+
+export function AreasAcessoCard({ coordenadorias }: AreasAcessoCardProps) {
+    if (coordenadorias.length === 0) {
+        return (
+            <section className="rounded-2xl bg-white p-6 shadow-sm">
+                <h2 className="mb-4 text-base font-bold text-foreground">Áreas de acesso</h2>
+                <p className="text-sm text-muted-foreground">Nenhuma área de acesso disponível.</p>
+            </section>
+        );
+    }
+
+    return (
+        <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <h2 className="mb-4 text-base font-bold text-foreground">Áreas de acesso</h2>
+
+            <ul className="flex flex-col gap-3">
+                {coordenadorias.map((coord) => (
+                    <li
+                        key={coord.sigla}
+                        className="flex flex-col gap-3 rounded-lg bg-zinc-50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between"
+                    >
+                        <div className="flex items-center gap-3">
+                            <div className="flex size-10 items-center justify-center rounded-lg bg-indigo-100">
+                                <CoordenadoriaIcon sigla={coord.sigla} />
+                            </div>
+                            <div>
+                                <p className="text-sm font-semibold text-foreground">{coord.sigla}</p>
+                                <p className="text-xs text-muted-foreground">{coord.descricao}</p>
+                            </div>
+                        </div>
+
+                        <div className="flex flex-wrap gap-2">
+                            {coord.areas.map((area) => (
+                                <span
+                                    key={`${coord.sigla}-${area}`}
+                                    className="inline-flex items-center rounded-md bg-indigo-50 px-3 py-1 text-xs font-semibold text-indigo-700"
+                                >
+                                    {area}
+                                </span>
+                            ))}
+                        </div>
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}

--- a/src/components/perfil/DadosPessoaisCard.tsx
+++ b/src/components/perfil/DadosPessoaisCard.tsx
@@ -1,0 +1,60 @@
+import { Pencil } from "lucide-react";
+
+type Field = Readonly<{
+    label: string;
+    value: string;
+}>;
+
+type DadosPessoaisCardProps = Readonly<{
+    nomeCompleto: string;
+    cpf: string;
+    email: string;
+    cargo: string;
+    coordenadoria: string;
+    onEditar?: () => void;
+}>;
+
+function FieldItem({ label, value }: Field) {
+    return (
+        <div>
+            <p className="text-sm text-muted-foreground">{label}</p>
+            <p className="mt-1 text-sm font-semibold text-foreground break-words">{value}</p>
+        </div>
+    );
+}
+
+export function DadosPessoaisCard({
+    nomeCompleto,
+    cpf,
+    email,
+    cargo,
+    coordenadoria,
+    onEditar,
+}: DadosPessoaisCardProps) {
+    return (
+        <section className="rounded-2xl bg-white p-6 shadow-sm">
+            <header className="mb-6 flex items-start justify-between">
+                <h2 className="text-base font-bold text-foreground">Dados pessoais</h2>
+                <button
+                    type="button"
+                    onClick={onEditar}
+                    className="inline-flex items-center gap-1.5 text-sm font-semibold text-sky-600 underline-offset-4 hover:underline focus:outline-none focus-visible:underline"
+                    data-testid="btn-editar-dados"
+                    aria-label="Editar dados pessoais"
+                >
+                    <Pencil className="size-4" aria-hidden="true" />
+                    Editar
+                </button>
+            </header>
+
+            <div className="grid grid-cols-1 gap-x-8 gap-y-5 md:grid-cols-2">
+                <FieldItem label="Nome completo" value={nomeCompleto} />
+                <FieldItem label="CPF" value={cpf} />
+                <FieldItem label="E-mail" value={email} />
+                <div className="hidden md:block" aria-hidden="true" />
+                <FieldItem label="Cargo" value={cargo} />
+                <FieldItem label="Coordenadoria" value={coordenadoria} />
+            </div>
+        </section>
+    );
+}

--- a/src/components/perfil/DadosPessoaisCard.tsx
+++ b/src/components/perfil/DadosPessoaisCard.tsx
@@ -32,7 +32,7 @@ export function DadosPessoaisCard({
     onEditar,
 }: DadosPessoaisCardProps) {
     return (
-        <section className="rounded-2xl bg-white p-6 shadow-sm">
+        <section className="rounded-lg bg-white p-6 shadow-lg">
             <header className="mb-6 flex items-start justify-between">
                 <h2 className="text-base font-bold text-foreground">Dados pessoais</h2>
                 <button

--- a/src/components/perfil/IdentityCard.tsx
+++ b/src/components/perfil/IdentityCard.tsx
@@ -1,0 +1,49 @@
+import { Check } from "lucide-react";
+
+type IdentityCardProps = Readonly<{
+    nomeCompleto: string;
+    cargo: string;
+    coordenadoria: string;
+    contaAtiva: boolean;
+    ultimoAcesso: string;
+    tempoSessao: string;
+}>;
+
+export function IdentityCard({
+    nomeCompleto,
+    cargo,
+    coordenadoria,
+    contaAtiva,
+    ultimoAcesso,
+    tempoSessao,
+}: IdentityCardProps) {
+    return (
+        <div className="rounded-2xl bg-white p-6 shadow-sm">
+            <div className="flex flex-col items-center text-center">
+                <h2 className="text-xl font-bold text-foreground">{nomeCompleto}</h2>
+                <p className="mt-2 text-sm text-muted-foreground">{cargo}</p>
+                <p className="text-sm text-muted-foreground">{coordenadoria}</p>
+
+                {contaAtiva && (
+                    <span className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-700">
+                        <Check className="size-4" aria-hidden="true" />
+                        Conta ativa
+                    </span>
+                )}
+            </div>
+
+            <hr className="my-6 border-zinc-200" />
+
+            <dl className="space-y-4 text-center">
+                <div>
+                    <dt className="text-sm text-muted-foreground">Último acesso</dt>
+                    <dd className="mt-1 text-sm font-semibold text-foreground">{ultimoAcesso}</dd>
+                </div>
+                <div>
+                    <dt className="text-sm text-muted-foreground">Tempo de sessão</dt>
+                    <dd className="mt-1 text-sm font-semibold text-foreground">{tempoSessao}</dd>
+                </div>
+            </dl>
+        </div>
+    );
+}

--- a/src/components/perfil/IdentityCard.tsx
+++ b/src/components/perfil/IdentityCard.tsx
@@ -18,7 +18,7 @@ export function IdentityCard({
     tempoSessao,
 }: IdentityCardProps) {
     return (
-        <div className="rounded-2xl bg-white p-6 shadow-sm">
+        <div className="rounded-lg bg-white p-6 shadow-lg">
             <div className="flex flex-col items-center text-center">
                 <h2 className="text-xl font-bold text-foreground">{nomeCompleto}</h2>
                 <p className="mt-2 text-sm text-muted-foreground">{cargo}</p>

--- a/src/components/perfil/ProfileLink.tsx
+++ b/src/components/perfil/ProfileLink.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import PerfilIcon from "@/assets/icons/Perfil";
+import { cn } from "@/lib/utils";
+
+interface ProfileLinkProps {
+    className?: string;
+    showLabel?: boolean;
+}
+
+export default function ProfileLink({
+    className = "",
+    showLabel = true,
+}: Readonly<ProfileLinkProps>) {
+    return (
+        <Link
+            href="/perfil"
+            aria-label="Acessar meu perfil"
+            data-testid="btn-perfil"
+            className={cn(
+                "inline-flex items-center gap-2 py-2 text-sm font-medium text-white [&_svg]:size-7",
+                showLabel ? "px-4" : "px-0",
+                className,
+            )}
+        >
+            {showLabel && <span>Perfil</span>}
+            <PerfilIcon />
+        </Link>
+    );
+}

--- a/src/components/perfil/areasAcessoConfig.ts
+++ b/src/components/perfil/areasAcessoConfig.ts
@@ -1,6 +1,5 @@
 import type { AreaAcesso } from "@/types/areaAcesso";
 
-// TODO: substituir por permissões reais quando o backend expuser as áreas por coordenadoria.
 export const AREAS_POR_COORDENADORIA: Record<string, AreaAcesso[]> = {
     ASCOM: ["Analytics"],
     CODAE: ["Operacional", "Saúde do deploy"],

--- a/src/components/perfil/areasAcessoConfig.ts
+++ b/src/components/perfil/areasAcessoConfig.ts
@@ -1,0 +1,12 @@
+import type { AreaAcesso } from "@/types/areaAcesso";
+
+// TODO: substituir por permissões reais quando o backend expuser as áreas por coordenadoria.
+export const AREAS_POR_COORDENADORIA: Record<string, AreaAcesso[]> = {
+    ASCOM: ["Analytics"],
+    CODAE: ["Operacional", "Saúde do deploy"],
+    COGEP: ["Operacional", "Analytics"],
+    COPED: ["Operacional", "Analytics", "Saúde do deploy"],
+    COPLAN: ["Operacional"],
+    COTIC: ["Operacional", "Analytics"],
+    GIPE: ["Operacional", "Analytics", "Saúde do deploy"],
+};

--- a/src/hooks/useAreasAcesso.ts
+++ b/src/hooks/useAreasAcesso.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { useMemo } from "react";
+import { useAllowedSquads } from "@/hooks/useAllowedSquads";
+import { getSistemasPorSquad } from "@/components/dashboard/SelectSistemas/getSistemasPorSquad";
+import { AREAS_POR_COORDENADORIA } from "@/components/perfil/areasAcessoConfig";
+import type { CoordenadoriaAcesso } from "@/types/coordenadoriaAcesso";
+
+export function useAreasAcesso(): CoordenadoriaAcesso[] {
+    const allowedSquads = useAllowedSquads();
+
+    return useMemo(() => {
+        return allowedSquads
+            .map<CoordenadoriaAcesso | null>((sigla) => {
+                const areas = AREAS_POR_COORDENADORIA[sigla.toUpperCase()];
+                if (!areas || areas.length === 0) return null;
+
+                const sistemas = getSistemasPorSquad(sigla);
+                const descricao = sistemas.map((s) => s.nome).join(" - ");
+
+                return {
+                    sigla,
+                    descricao: descricao || sigla,
+                    areas,
+                };
+            })
+            .filter((item): item is CoordenadoriaAcesso => item !== null);
+    }, [allowedSquads]);
+}

--- a/src/lib/auth/logic.ts
+++ b/src/lib/auth/logic.ts
@@ -51,6 +51,10 @@ export async function authorizeUser(
     const groups = loginResponse.groups ?? [];
     const given_name = loginResponse.given_name;
     const family_name = loginResponse.family_name;
+    const cargo = loginResponse.cargo;
+    const coordenadoria = loginResponse.coordenadoria;
+    const ultimo_acesso = loginResponse.ultimo_acesso;
+    const tempo_sessao = loginResponse.tempo_sessao;
 
     if (!name || !id) {
         throw new Error("Erro interno no servidor!");
@@ -69,6 +73,10 @@ export async function authorizeUser(
         groups,
         given_name,
         family_name,
+        cargo,
+        coordenadoria,
+        ultimo_acesso,
+        tempo_sessao,
     };
 }
 
@@ -86,6 +94,10 @@ export function jwtCallback({ token, user }: { token: JWT; user?: User }): JWT {
         token.groups = user.groups;
         token.given_name = user.given_name;
         token.family_name = user.family_name;
+        token.cargo = user.cargo;
+        token.coordenadoria = user.coordenadoria;
+        token.ultimo_acesso = user.ultimo_acesso;
+        token.tempo_sessao = user.tempo_sessao;
     }
 
     token.exp = Math.floor(Date.now() / 1000) + TOKEN_MAX_AGE_SECONDS;
@@ -115,6 +127,10 @@ export function sessionCallback({
         session.user.groups = token.groups;
         session.user.given_name = token.given_name;
         session.user.family_name = token.family_name;
+        session.user.cargo = token.cargo;
+        session.user.coordenadoria = token.coordenadoria;
+        session.user.ultimo_acesso = token.ultimo_acesso;
+        session.user.tempo_sessao = token.tempo_sessao;
         session.expires_at = token.exp;
     }
     return session;

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { cn, numberToBRL, decodeJwt, formatDDMMYYYY_HHMM_FromMillis, formatDurationMs } from "./utils";
+import {
+    cn,
+    numberToBRL,
+    decodeJwt,
+    formatDDMMYYYY_HHMM_FromMillis,
+    formatDurationMs,
+    formatCpfMasked,
+    formatUltimoAcesso,
+} from "./utils";
 
 describe("Função cn (clsx + tailwind-merge)", () => {
   it("retorna uma string combinada de classes", () => {
@@ -87,5 +95,47 @@ describe("formatDDMMYYYY_HHMM_FromMillis", () => {
     const hh = String(d.getHours()).padStart(2, "0");
     const mi = String(d.getMinutes()).padStart(2, "0");
     expect(formatDDMMYYYY_HHMM_FromMillis(ms)).toBe(`${dd}/${mm}/${yyyy} ${hh}:${mi}`);
+  });
+});
+
+describe("formatCpfMasked", () => {
+  it("retorna undefined quando o CPF é vazio ou ausente", () => {
+    expect(formatCpfMasked(undefined)).toBeUndefined();
+    expect(formatCpfMasked("")).toBeUndefined();
+  });
+
+  it("mascara os últimos cinco dígitos do CPF", () => {
+    expect(formatCpfMasked("12345678901")).toBe("123.456.xxx-xx");
+  });
+
+  it("remove caracteres não numéricos antes de mascarar", () => {
+    expect(formatCpfMasked("123.456.789-01")).toBe("123.456.xxx-xx");
+  });
+
+  it("retorna undefined quando o CPF tem mais de 11 dígitos", () => {
+    expect(formatCpfMasked("123456789012")).toBeUndefined();
+  });
+
+  it("normaliza com padStart quando o CPF tem menos de 11 dígitos", () => {
+    expect(formatCpfMasked("4567890123")).toBe("045.678.xxx-xx");
+  });
+});
+
+describe("formatUltimoAcesso", () => {
+  it("retorna undefined quando o valor é vazio ou ausente", () => {
+    expect(formatUltimoAcesso(undefined)).toBeUndefined();
+    expect(formatUltimoAcesso("")).toBeUndefined();
+  });
+
+  it("converte o formato 'YYYY-MM-DD HH:MM' para 'DD/MM/YYYY HH:MM'", () => {
+    expect(formatUltimoAcesso("2026-05-25 14:37")).toBe("25/05/2026 14:37");
+  });
+
+  it("aceita também o separador 'T' entre data e hora", () => {
+    expect(formatUltimoAcesso("2026-05-25T09:05")).toBe("25/05/2026 09:05");
+  });
+
+  it("retorna o valor original quando não corresponde ao padrão esperado", () => {
+    expect(formatUltimoAcesso("data-invalida")).toBe("data-invalida");
   });
 });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -59,6 +59,14 @@ export function formatCpfMasked(cpf?: string): string | undefined {
     return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.xxx-xx`;
 }
 
+export function formatUltimoAcesso(value?: string): string | undefined {
+    if (!value) return undefined;
+    const match = /^(\d{4})-(\d{2})-(\d{2})[ T](\d{2}):(\d{2})/.exec(value);
+    if (!match) return value;
+    const [, yyyy, mm, dd, hh, mi] = match;
+    return `${dd}/${mm}/${yyyy} ${hh}:${mi}`;
+}
+
 export function decodeJwt(token: string) {
     const payload = token.split('.')[1];
     return JSON.parse(Buffer.from(payload, 'base64').toString('utf-8'));

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -52,6 +52,13 @@ export function formatDurationMs(ms?: number): string | undefined {
     return `${seconds}s`;
 }
 
+export function formatCpfMasked(cpf?: string): string | undefined {
+    if (!cpf) return undefined;
+    const digits = cpf.replace(/\D/g, "").padStart(11, "0");
+    if (digits.length !== 11) return undefined;
+    return `${digits.slice(0, 3)}.${digits.slice(3, 6)}.xxx-xx`;
+}
+
 export function decodeJwt(token: string) {
     const payload = token.split('.')[1];
     return JSON.parse(Buffer.from(payload, 'base64').toString('utf-8'));

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ function isSessionExpired(expiresAt: number | undefined): boolean {
 export default auth((req) => {
     const { pathname } = req.nextUrl;
 
-    const protectedRoutes = ["/dashboard"];
+    const protectedRoutes = ["/dashboard", "/perfil"];
 
     const isProtectedRoute = protectedRoutes.some((route) =>
         pathname.startsWith(route)

--- a/src/types/areaAcesso.ts
+++ b/src/types/areaAcesso.ts
@@ -1,0 +1,1 @@
+export type AreaAcesso = "Operacional" | "Analytics" | "Saúde do deploy";

--- a/src/types/coordenadoriaAcesso.ts
+++ b/src/types/coordenadoriaAcesso.ts
@@ -1,0 +1,7 @@
+import type { AreaAcesso } from "./areaAcesso";
+
+export interface CoordenadoriaAcesso {
+    sigla: string;
+    descricao: string;
+    areas: AreaAcesso[];
+}

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -27,4 +27,8 @@ export type LoginResponse = {
     preferred_username?: string;
     given_name?: string;
     family_name?: string;
+    cargo?: string;
+    coordenadoria?: string;
+    ultimo_acesso?: string;
+    tempo_sessao?: string;
 };

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -16,6 +16,10 @@ declare module "next-auth" {
         groups?: string[];
         given_name?: string;
         family_name?: string;
+        cargo?: string;
+        coordenadoria?: string;
+        ultimo_acesso?: string;
+        tempo_sessao?: string;
     }
 
     interface Session extends DefaultSession {
@@ -32,6 +36,10 @@ declare module "next-auth" {
             groups?: string[];
             given_name?: string;
             family_name?: string;
+            cargo?: string;
+            coordenadoria?: string;
+            ultimo_acesso?: string;
+            tempo_sessao?: string;
         } & DefaultSession["user"];
         expires_at?: number;
     }
@@ -51,6 +59,10 @@ declare module "next-auth/jwt" {
         groups?: string[];
         given_name?: string;
         family_name?: string;
+        cargo?: string;
+        coordenadoria?: string;
+        ultimo_acesso?: string;
+        tempo_sessao?: string;
         exp?: number;
     }
 }

--- a/src/types/perfilUsuario.ts
+++ b/src/types/perfilUsuario.ts
@@ -1,0 +1,13 @@
+import type { CoordenadoriaAcesso } from "./coordenadoriaAcesso";
+
+export interface PerfilUsuario {
+    nomeCompleto: string;
+    cargo: string;
+    coordenadoria: string;
+    cpf: string;
+    email: string;
+    contaAtiva: boolean;
+    ultimoAcesso: string;
+    tempoSessao: string;
+    coordenadoriasAcesso: CoordenadoriaAcesso[];
+}


### PR DESCRIPTION
[AB#149012](https://dev.azure.com/SME-Spassu/COTIC%20-%20Desenvolvimento/_sprints/taskboard/COTIC%20-%20Desenvolvimento%20Team/COTIC%20-%20Desenvolvimento/Ciclo%20012%20-%20Mai26?workitem=149012)

## Resumo
Adiciona a tela **Meu perfil** em `/perfil`, protegida pelo middleware, com cartões de identidade, dados pessoais, ações da conta e áreas de acesso por squad. Sidebar ganha botão **Perfil** acima do **Sair**.

## Como testar
- Logar e abrir `/perfil` pelo botão da sidebar; validar dados do usuário, CPF mascarado e áreas de acesso
- Acessar `/perfil` sem sessão e confirmar o redirecionamento
- Estando em `/perfil`, clicar numa coordenadoria da sidebar e validar a navegação para `/dashboard`