### PR TITLE
fix(perfil): exibe conta inativa e ajusta layout das áreas de acesso

### DIFF
--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -15,8 +15,10 @@ export default function PerfilPage() {
     const { data: session } = useSession();
     const coordenadoriasAcesso = useAreasAcesso();
 
+    const AUTH_VERSION = process.env.NEXT_PUBLIC_AUTH_VERSION ?? "v1";
+
     const nomeCompleto = session?.user?.name ?? EMPTY_FIELD;
-    const contaAtiva = session?.user?.situacaoUsuario === SITUACAO_USUARIO_ATIVO;
+    const contaAtiva = AUTH_VERSION === "v2" || session?.user?.situacaoUsuario === SITUACAO_USUARIO_ATIVO;
     const cpf = formatCpfMasked(session?.user?.cpf) ?? EMPTY_FIELD;
     const email = session?.user?.email ?? EMPTY_FIELD;
     const cargo = session?.user?.cargo ?? EMPTY_FIELD;

--- a/src/components/perfil/AreasAcessoCard.tsx
+++ b/src/components/perfil/AreasAcessoCard.tsx
@@ -60,7 +60,7 @@ export function AreasAcessoCard({ coordenadorias }: AreasAcessoCardProps) {
                             </div>
                         </div>
 
-                        <div className="flex flex-wrap gap-2">
+                        <div className="flex flex-wrap gap-2 justify-end">
                             {coord.areas.map((area) => (
                                 <span
                                     key={`${coord.sigla}-${area}`}

--- a/src/components/perfil/IdentityCard.tsx
+++ b/src/components/perfil/IdentityCard.tsx
@@ -1,4 +1,4 @@
-import { Check } from "lucide-react";
+import { Check, X } from "lucide-react";
 
 type IdentityCardProps = Readonly<{
     nomeCompleto: string;
@@ -23,11 +23,16 @@ export function IdentityCard({
                 <h2 className="text-xl font-bold text-foreground">{nomeCompleto}</h2>
                 <p className="mt-2 text-sm text-muted-foreground">{cargo}</p>
                 <p className="text-sm text-muted-foreground">{coordenadoria}</p>
-
-                {contaAtiva && (
-                    <span className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-emerald-100 px-3 py-1 text-sm font-medium text-emerald-700">
-                        <Check className="size-4" aria-hidden="true" />
+                
+                {contaAtiva ? (
+                    <span className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-[#e6fbf2] px-4 py-1.5 text-sm font-medium text-[#096643]">
+                        <Check className="size-4 stroke-[2.5]" aria-hidden="true" />
                         Conta ativa
+                    </span>
+                ) : (
+                    <span className="mt-4 inline-flex items-center gap-1.5 rounded-full bg-[#fff0f0] px-4 py-1.5 text-sm font-medium text-[#c92a2a]">
+                        <X className="size-4 stroke-[2.5]" aria-hidden="true" />
+                        Conta inativa
                     </span>
                 )}
             </div>


### PR DESCRIPTION
[AB#149012](https://dev.azure.com/SME-Spassu/COTIC%20-%20Desenvolvimento/_sprints/taskboard/COTIC%20-%20Desenvolvimento%20Team/COTIC%20-%20Desenvolvimento/Ciclo%20012%20-%20Mai26?workitem=149012)

## Resumo
- Adiciona o badge **Conta inativa** no `IdentityCard` quando `situacaoUsuario` indica conta desativada, com ícone `X` e paleta vermelha
- Considera contas autenticadas via Keycloak (`NEXT_PUBLIC_AUTH_VERSION=v2`) como ativas, já que esse fluxo não retorna `situacaoUsuario`
- Alinha à direita as tags de áreas de acesso por coordenadoria no `AreasAcessoCard`

## Como testar
- Logar com um usuário cuja `situacaoUsuario` seja diferente de ativo e validar o badge **Conta inativa** em `/perfil`
- Logar com um usuário ativo e validar que o badge **Conta ativa** continua sendo exibido
- Configurar `NEXT_PUBLIC_AUTH_VERSION=v2` e validar que a conta aparece como ativa
- Abrir `/perfil` e validar o alinhamento à direita das tags de áreas em cada coordenadoria do `AreasAcessoCard`