### PR TITLE
chore(jenkins): adiciona defaults temporários para teste em homolog

### DIFF
--- a/src/lib/jenkins.server.test.ts
+++ b/src/lib/jenkins.server.test.ts
@@ -90,30 +90,34 @@ describe("jenkins client", () => {
         expect(createMock).toHaveBeenCalledTimes(2);
     });
 
-    it("lança erro quando JENKINS_USERNAME não está configurada", async () => {
+    it("usa username padrão quando JENKINS_USERNAME não está configurada", async () => {
         delete process.env.JENKINS_USERNAME;
         const mod = await import("./jenkins.server");
+        mod.jenkinsClient();
 
-        expect(() => mod.jenkinsClient()).toThrow(
-            "JENKINS_USERNAME não configurada",
-        );
+        const config = createMock!.mock.calls[0][0] as Record<string, unknown>;
+        const headers = config.headers as Record<string, string>;
+        expect(headers.Authorization).toMatch(/^Basic /);
     });
 
-    it("lança erro quando JENKINS_API_TOKEN não está configurada", async () => {
+    it("usa token padrão quando JENKINS_API_TOKEN não está configurada", async () => {
         delete process.env.JENKINS_API_TOKEN;
         const mod = await import("./jenkins.server");
+        mod.jenkinsClient();
 
-        expect(() => mod.jenkinsClient()).toThrow(
-            "JENKINS_API_TOKEN não configurada",
-        );
+        const config = createMock!.mock.calls[0][0] as Record<string, unknown>;
+        const headers = config.headers as Record<string, string>;
+        expect(headers.Authorization).toMatch(/^Basic /);
     });
 
-    it("lança erro quando JENKINS_URL não está configurada", async () => {
+    it("usa URL padrão quando JENKINS_URL não está configurada", async () => {
         delete process.env.JENKINS_URL;
         const mod = await import("./jenkins.server");
+        mod.jenkinsClient();
 
-        expect(() => mod.jenkinsClient()).toThrow(
-            "JENKINS_URL não configurada",
+        const config = createMock!.mock.calls[0][0] as Record<string, unknown>;
+        expect(config.baseURL).toBe(
+            "https://jenkins2.sme.prefeitura.sp.gov.br",
         );
     });
 

--- a/src/lib/jenkins.server.ts
+++ b/src/lib/jenkins.server.ts
@@ -3,28 +3,31 @@ import axios, { AxiosInstance } from "axios";
 
 let cachedClient: AxiosInstance | null = null;
 
+// TEMPORÁRIO: defaults hardcoded para teste em homolog. Reverter na PR de retorno.
+const DEFAULT_JENKINS_URL = "https://jenkins2.sme.prefeitura.sp.gov.br";
+const DEFAULT_JENKINS_USERNAME = "luis_dourado";
+const DEFAULT_JENKINS_API_TOKEN = "11bc982264a24499ca2eea10e804685047";
+const DEFAULT_JENKINS_TIMEOUT_MS = 10000;
+
 function getJenkinsBaseUrl(): string {
-  const url = process.env.JENKINS_URL;
-  if (!url) throw new Error("JENKINS_URL não configurada");
+  const url = process.env.JENKINS_URL ?? DEFAULT_JENKINS_URL;
   return url.replace(/\/$/, "");
 }
 
 function getJenkinsUsername(): string {
-  const username = process.env.JENKINS_USERNAME;
-  if (!username) throw new Error("JENKINS_USERNAME não configurada");
-  return username;
+  return process.env.JENKINS_USERNAME ?? DEFAULT_JENKINS_USERNAME;
 }
 
 function getJenkinsApiToken(): string {
-  const token = process.env.JENKINS_API_TOKEN;
-  if (!token) throw new Error("JENKINS_API_TOKEN não configurada");
-  return token;
+  return process.env.JENKINS_API_TOKEN ?? DEFAULT_JENKINS_API_TOKEN;
 }
 
 function getTimeout(): number {
   const raw = process.env.JENKINS_TIMEOUT_MS;
-  const parsed = raw ? Number(raw) : 10000;
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 10000;
+  const parsed = raw ? Number(raw) : DEFAULT_JENKINS_TIMEOUT_MS;
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_JENKINS_TIMEOUT_MS;
 }
 
 export function jenkinsClient(): AxiosInstance {


### PR DESCRIPTION
## Resumo
- Mudança **temporária** para viabilizar teste em homolog
- Hardcoda URL, username, token de teste e timeout do Jenkins como fallback quando as variáveis de ambiente não estão definidas
- PR de reversão já criada e pronta para merge após a validação

## Detalhes
Adicionado em `src/lib/jenkins.server.ts`:
- `JENKINS_URL` → default `https://jenkins2.sme.prefeitura.sp.gov.br`
- `JENKINS_USERNAME` → default `luis_dourado`
- `JENKINS_API_TOKEN` → default token de teste
- `JENKINS_TIMEOUT_MS` → default `10000`

Testes ajustados para refletir o novo comportamento (17/17 verdes).

## Como reverter
Merge da PR de retorno após validar o cenário de teste.