### PR TITLE
Fix/149876: Remover botões sem ação da tela de perfil

### DIFF
--- a/src/components/perfil/AccountActionsCard.tsx
+++ b/src/components/perfil/AccountActionsCard.tsx
@@ -17,7 +17,7 @@ export function AccountActionsCard({ onAlterarSenha }: AccountActionsCardProps) 
             <button
                 type="button"
                 onClick={onAlterarSenha}
-                className="text-sm font-semibold text-sky-600 underline-offset-4 hover:underline focus:outline-none focus-visible:underline"
+                className="hidden text-sm font-semibold text-sky-600 underline-offset-4 hover:underline focus:outline-none focus-visible:underline"
                 data-testid="btn-alterar-senha"
             >
                 Alterar senha

--- a/src/components/perfil/DadosPessoaisCard.tsx
+++ b/src/components/perfil/DadosPessoaisCard.tsx
@@ -38,7 +38,7 @@ export function DadosPessoaisCard({
                 <button
                     type="button"
                     onClick={onEditar}
-                    className="inline-flex items-center gap-1.5 text-sm font-semibold text-sky-600 underline-offset-4 hover:underline focus:outline-none focus-visible:underline"
+                    className="hidden items-center gap-1.5 text-sm font-semibold text-sky-600 underline-offset-4 hover:underline focus:outline-none focus-visible:underline"
                     data-testid="btn-editar-dados"
                     aria-label="Editar dados pessoais"
                 >


### PR DESCRIPTION
[AB#149876](https://dev.azure.com/SME-Spassu/COTIC%20-%20Desenvolvimento/_sprints/taskboard/COTIC%20-%20Desenvolvimento%20Team/COTIC%20-%20Desenvolvimento/Ciclo%20012%20-%20Mai26?workitem=149012)

Essa PR:

Oculta botões que estão sem ação (de forma temporária, será tratada em sprints futuras), via CSS.