### PR TITLE
fix(dashboard): restaura seção Lançamentos na aba Operacional

### DIFF
--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -100,6 +100,23 @@ vi.mock("@/components/dashboard/JenkinsJob", () => ({
     ),
 }));
 
+vi.mock("@/components/dashboard/Releases", () => ({
+    __esModule: true,
+    default: ({
+        title,
+        project,
+        subprojects,
+    }: {
+        title?: string;
+        project: string;
+        subprojects?: unknown[];
+    }) => (
+        <div data-testid={`releases-${title ?? "Lançamentos"}`}>
+            {project}::{Array.isArray(subprojects) ? subprojects.length : 0}
+        </div>
+    ),
+}));
+
 vi.mock("@/components/dashboard/DeployHealth/EnvironmentHeader", () => ({
     __esModule: true,
     default: () => <div data-testid="environment-header">Ambiente</div>,
@@ -251,6 +268,29 @@ describe("Dashboard page", () => {
         expect(jenkins).toHaveTextContent("Novo SGP::1");
         expect(jenkins.parentElement).toHaveClass("lg:col-span-1");
         expect(sonar.parentElement).toHaveClass("lg:col-span-3");
+    });
+
+    test("renderiza o card Lançamentos na aba Operacional", () => {
+        mockStoreState = {
+            ...mockStoreState,
+            activeItem: { title: "COPED" },
+            activeProject: {
+                nome: "Novo SGP",
+                zabbixQueryFrontend: "Portal SME",
+                zabbixQueryBackend: "API SME",
+                zabbixQueryFilasRabbitMQ: "Filas RabbitMQ",
+                jenkinsSubprojects: [
+                    { label: "Backend", key: "SME-NovoSGP/master" },
+                ],
+            },
+        };
+
+        render(withClient(<Dashboard />));
+
+        const releases = screen.getByTestId("releases-Lançamentos");
+
+        expect(releases).toHaveTextContent("Novo SGP::1");
+        expect(releases.parentElement).toHaveClass("col-span-2");
     });
 
     test("quando não há projeto ativo, passa strings vazias para os filhos (ramo do ??)", () => {

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import Producao from "@/components/dashboard/DisponibilidadeDosAmbientes/Produca
 import JenkinsJob from "@/components/dashboard/JenkinsJob";
 import PeakHoursChart from "@/components/dashboard/PeakHoursChart";
 import PeakUsageTodayCard from "@/components/dashboard/PeakUsageTodayCard";
+import Releases from "@/components/dashboard/Releases";
 import Filas from "@/components/dashboard/SaudeDosServidores/Filas";
 import UsersByPageCard from "@/components/dashboard/UsersByPageCard";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -83,6 +84,17 @@ export default function Dashboard() {
                 </TabsList>
 
                 <TabsContent value="operacional">
+                    <div className="grid grid-cols-4 gap-4 mb-4">
+                        <div
+                            id="onboarding-lancamentos"
+                            className="col-span-2"
+                        >
+                            <Releases
+                                project={projectName}
+                                subprojects={jenkinsSubprojects}
+                            />
+                        </div>
+                    </div>
                     <div className="grid grid-cols-4 gap-4 mb-4">
                         <CardWrapperInfoAmbientes
                             id="onboarding-disponibilidade"

--- a/src/components/dashboard/EnvironmentSelect/index.tsx
+++ b/src/components/dashboard/EnvironmentSelect/index.tsx
@@ -1,0 +1,43 @@
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+
+type Props = {
+    readonly value: "prod" | "homolog";
+    readonly onChange: (value: "prod" | "homolog") => void;
+};
+
+export function EnvironmentSelect({ value, onChange }: Props) {
+    return (
+        <Select
+            value={value}
+            onValueChange={(v) => onChange(v === "homolog" ? "homolog" : "prod")}
+        >
+            <SelectTrigger
+                size="sm"
+                className="w-auto rounded-full border-transparent bg-slate-100 px-3 text-xs font-medium text-slate-700 shadow-none hover:bg-slate-200 gap-1"
+                aria-label="Selecionar ambiente"
+            >
+                <SelectValue placeholder="Ambiente" />
+            </SelectTrigger>
+            <SelectContent>
+                <SelectItem
+                    value="prod"
+                    className="focus:bg-[#3b82f6] focus:text-white"
+                >
+                    Produção
+                </SelectItem>
+                <SelectItem
+                    value="homolog"
+                    className="focus:bg-[#3b82f6] focus:text-white"
+                >
+                    Homologação
+                </SelectItem>
+            </SelectContent>
+        </Select>
+    );
+}

--- a/src/components/dashboard/JenkinsJob/index.tsx
+++ b/src/components/dashboard/JenkinsJob/index.tsx
@@ -1,23 +1,15 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
 import JenkinsBranchBuildsCard from "@/components/dashboard/JenkinsBranchBuildsCard";
+import { SubprojectSelect } from "@/components/dashboard/SubprojectSelect";
 import { useJenkinsMetrics } from "@/hooks/useJenkinsMetrics";
+import { useSubprojectSelection } from "@/hooks/useSubprojectSelection";
 import { cn } from "@/lib/utils";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
 import type { JenkinsSubproject } from "@/types/jenkinsSubproject";
 import {
     getJenkinsEnvironmentForDeploy,
     type DeployEnvironment,
 } from "@/types/deployEnvironment";
-
-const EMPTY_SUBPROJECTS: JenkinsSubproject[] = [];
 
 type Props = {
     readonly project: string;
@@ -34,30 +26,9 @@ export default function JenkinsJob({
     subprojects: subprojectsProp,
     environment = "producao",
 }: Props) {
-    const subprojects = useMemo(
-        () => subprojectsProp ?? EMPTY_SUBPROJECTS,
-        [subprojectsProp]
-    );
-    const hasMultipleSubprojects = subprojects.length > 1;
-
-    const [selectedKey, setSelectedKey] = useState("");
+    const { subprojects, hasMultipleSubprojects, selectedKey, setSelectedKey } =
+        useSubprojectSelection(project, subprojectsProp);
     const jenkinsEnvironment = getJenkinsEnvironmentForDeploy(environment);
-
-    useEffect(() => {
-        if (!project || subprojects.length === 0) {
-            setSelectedKey("");
-            return;
-        }
-
-        if (subprojects.length === 1) {
-            setSelectedKey(subprojects[0].key);
-            return;
-        }
-
-        setSelectedKey((prev) =>
-            subprojects.some((s) => s.key === prev) ? prev : subprojects[0].key
-        );
-    }, [project, subprojects]);
 
     const query = useJenkinsMetrics({
         projectName: selectedKey,
@@ -91,32 +62,11 @@ export default function JenkinsJob({
             <div className={cn("bg-white rounded-[5px] shadow-[3px_4px_6px_0px_rgba(0,0,0,0.1)] p-5", className)}>
                 <div className="font-bold text-[14px] text-[#111827] mb-4">{title}</div>
 
-                <div className="mb-4">
-                    <div className="text-sm font-semibold text-[#111827] mb-2">Projeto</div>
-                    <Select
-                        value={selectedKey}
-                        onValueChange={(value) => setSelectedKey(value)}
-                    >
-                        <SelectTrigger
-                            size="sm"
-                            className="w-full"
-                            aria-label="Selecionar projeto"
-                        >
-                            <SelectValue placeholder="Selecione" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {subprojects.map((s) => (
-                                <SelectItem
-                                    key={s.key}
-                                    value={s.key}
-                                    className="focus:bg-[#3b82f6] focus:text-white"
-                                >
-                                    {s.label}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                </div>
+                <SubprojectSelect
+                    value={selectedKey}
+                    onChange={setSelectedKey}
+                    subprojects={subprojects}
+                />
 
                 <JenkinsBranchBuildsCard
                     title=""

--- a/src/components/dashboard/JenkinsJobCard.tsx
+++ b/src/components/dashboard/JenkinsJobCard.tsx
@@ -5,13 +5,7 @@ import { RotateCcw, Clock, Calendar } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
+import { EnvironmentSelect } from "@/components/dashboard/EnvironmentSelect";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { JenkinsJobSummary } from "@/types/jenkins";
 
@@ -26,43 +20,6 @@ type Props = {
     readonly showEnvironmentSelect?: boolean;
     readonly contentOnly?: boolean;
 };
-
-function EnvironmentSelect({ 
-    value, 
-    onChange 
-}: { 
-    readonly value: "prod" | "homolog"; 
-    readonly onChange: (v: "prod" | "homolog") => void;
-}) {
-    return (
-        <Select
-            value={value}
-            onValueChange={(v) => onChange(v === "homolog" ? "homolog" : "prod")}
-        >
-            <SelectTrigger
-                size="sm"
-                className="w-auto rounded-full border-transparent bg-slate-100 px-3 text-xs font-medium text-slate-700 shadow-none hover:bg-slate-200 gap-1"
-                aria-label="Selecionar ambiente"
-            >
-                <SelectValue placeholder="Ambiente" />
-            </SelectTrigger>
-            <SelectContent>
-                <SelectItem
-                    value="prod"
-                    className="focus:bg-[#3b82f6] focus:text-white"
-                >
-                    Produção
-                </SelectItem>
-                <SelectItem
-                    value="homolog"
-                    className="focus:bg-[#3b82f6] focus:text-white"
-                >
-                    Homologação
-                </SelectItem>
-            </SelectContent>
-        </Select>
-    );
-}
 
 type HeaderProps = {
     readonly title: string;

--- a/src/components/dashboard/Releases/index.test.tsx
+++ b/src/components/dashboard/Releases/index.test.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { withClient } from "@/__mocks__/renderWithClient";
+import Releases from "./index";
+
+function okJson(data: unknown) {
+  return {
+    ok: true,
+    json: async () => data,
+  } as unknown as Response;
+}
+
+function fetchUrl(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (input instanceof URL) return input.toString();
+  return input.url;
+}
+
+describe("<Releases />", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("com múltiplos subprojetos: mostra select e atualiza automaticamente ao trocar", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url = fetchUrl(input);
+
+      if (url.startsWith("/api/zabbix/jenkins/job?project=PTRF-FrontEnd&env=homolog")) {
+        return okJson({
+          lastBuild: {
+            number: 99,
+            status: "SUCCESS",
+            timestampMs: 99,
+            timestamp: "03/01/2024 00:00",
+            durationMs: 99000,
+            duration: "99s",
+          },
+        });
+      }
+
+      if (url.startsWith("/api/zabbix/jenkins/job?project=PTRF-BackEnd")) {
+        return okJson({
+          lastBuild: {
+            number: 1,
+            status: "SUCCESS",
+            timestampMs: 1,
+            timestamp: "01/01/2024 00:00",
+            durationMs: 1000,
+            duration: "1s",
+          },
+        });
+      }
+
+      if (url.startsWith("/api/zabbix/jenkins/job?project=PTRF-FrontEnd")) {
+        return okJson({
+          lastBuild: {
+            number: 2,
+            status: "FAILURE",
+            timestampMs: 2,
+            timestamp: "02/01/2024 00:00",
+            durationMs: 2000,
+            duration: "2s",
+          },
+        });
+      }
+
+      throw new Error(`fetch inesperado: ${url}`);
+    });
+
+    render(
+      withClient(
+        <Releases
+          project="SigEscola"
+          subprojects={[
+            { label: "Backend", key: "PTRF-BackEnd" },
+            { label: "Frontend", key: "PTRF-FrontEnd" },
+          ]}
+        />
+      )
+    );
+
+    expect(await screen.findByText("Projeto")).toBeInTheDocument();
+    expect(await screen.findByLabelText("Selecionar ambiente")).toHaveTextContent("Produção");
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/zabbix/jenkins/job?project=PTRF-BackEnd",
+        expect.any(Object)
+      );
+    });
+
+    const trigger = screen.getByLabelText("Selecionar projeto");
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByText("Frontend"));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/zabbix/jenkins/job?project=PTRF-FrontEnd",
+        expect.any(Object)
+      );
+    });
+
+    const envTrigger = screen.getByLabelText("Selecionar ambiente");
+    fireEvent.click(envTrigger);
+    fireEvent.click(screen.getByText("Homologação"));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/zabbix/jenkins/job?project=PTRF-FrontEnd&env=homolog",
+        expect.any(Object)
+      );
+    });
+
+    expect(screen.getByLabelText("Selecionar ambiente")).toHaveTextContent("Homologação");
+  });
+
+  it("com apenas 1 subprojeto: não exige seleção adicional", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url = fetchUrl(input);
+
+      if (url.startsWith("/api/zabbix/jenkins/job?project=SME-NovoSGP")) {
+        return okJson({
+          lastBuild: {
+            number: 1,
+            status: "SUCCESS",
+            timestampMs: 1,
+            timestamp: "01/01/2024 00:00",
+            durationMs: 1000,
+            duration: "1s",
+          },
+        });
+      }
+
+      throw new Error(`fetch inesperado: ${url}`);
+    });
+
+    render(
+      withClient(
+        <Releases project="Novo SGP" subprojects={[{ label: "SME-NovoSGP", key: "SME-NovoSGP" }]} />
+      )
+    );
+
+    expect(screen.queryByText("Projeto")).not.toBeInTheDocument();
+    expect(await screen.findByLabelText("Selecionar ambiente")).toHaveTextContent("Produção");
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/zabbix/jenkins/job?project=SME-NovoSGP",
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("projeto N/E (ou sem chaves): não busca releases e mostra mensagem", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url = fetchUrl(input);
+
+      if (url.startsWith("/api/zabbix/jenkins/job?")) {
+        throw new Error("Não deveria chamar endpoint de job");
+      }
+
+      throw new Error(`fetch inesperado: ${url}`);
+    });
+
+    render(withClient(<Releases project="Portal Educação" subprojects={[]} />));
+
+    expect(
+      await screen.findByText("Sem lançamentos disponíveis para este projeto.")
+    ).toBeInTheDocument();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/dashboard/Releases/index.test.tsx
+++ b/src/components/dashboard/Releases/index.test.tsx
@@ -152,6 +152,17 @@ describe("<Releases />", () => {
     });
   });
 
+  it("sem projeto: mostra seletor de ambiente e não busca releases", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      throw new Error(`fetch inesperado: ${fetchUrl(input)}`);
+    });
+
+    render(withClient(<Releases project="" subprojects={[]} />));
+
+    expect(await screen.findByLabelText("Selecionar ambiente")).toHaveTextContent("Produção");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("projeto N/E (ou sem chaves): não busca releases e mostra mensagem", async () => {
     const fetchSpy = vi.spyOn(global, "fetch").mockImplementation(async (input) => {
       const url = fetchUrl(input);

--- a/src/components/dashboard/Releases/index.tsx
+++ b/src/components/dashboard/Releases/index.tsx
@@ -1,19 +1,13 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useState } from "react";
 import JenkinsJobCard from "@/components/dashboard/JenkinsJobCard";
+import { EnvironmentSelect } from "@/components/dashboard/EnvironmentSelect";
+import { SubprojectSelect } from "@/components/dashboard/SubprojectSelect";
 import { useJenkinsJob } from "@/hooks/useJenkinsJob";
+import { useSubprojectSelection } from "@/hooks/useSubprojectSelection";
 import { cn } from "@/lib/utils";
-import {
-    Select,
-    SelectContent,
-    SelectItem,
-    SelectTrigger,
-    SelectValue,
-} from "@/components/ui/select";
 import type { JenkinsSubproject } from "@/types/jenkinsSubproject";
-
-const EMPTY_SUBPROJECTS: JenkinsSubproject[] = [];
 
 type Props = {
     readonly project: string;
@@ -28,30 +22,9 @@ export default function Releases({
     project,
     subprojects: subprojectsProp,
 }: Props) {
-    const subprojects = useMemo(
-        () => subprojectsProp ?? EMPTY_SUBPROJECTS,
-        [subprojectsProp]
-    );
-    const hasMultipleSubprojects = subprojects.length > 1;
-
-    const [selectedKey, setSelectedKey] = useState("");
+    const { subprojects, hasMultipleSubprojects, selectedKey, setSelectedKey } =
+        useSubprojectSelection(project, subprojectsProp);
     const [environment, setEnvironment] = useState<"prod" | "homolog">("prod");
-
-    useEffect(() => {
-        if (!project || subprojects.length === 0) {
-            setSelectedKey("");
-            return;
-        }
-
-        if (subprojects.length === 1) {
-            setSelectedKey(subprojects[0].key);
-            return;
-        }
-
-        setSelectedKey((prev) =>
-            subprojects.some((s) => s.key === prev) ? prev : subprojects[0].key
-        );
-    }, [project, subprojects]);
 
     const query = useJenkinsJob({
         endpoint: "/api/zabbix/jenkins/job",
@@ -90,54 +63,17 @@ export default function Releases({
             <div className={cn("bg-white rounded-[5px] shadow-[3px_4px_6px_0px_rgba(0,0,0,0.1)] p-5", className)}>
                 <div className="flex items-center justify-between mb-4">
                     <span className="font-bold text-[14px] text-[#111827]">{title}</span>
-                    <Select
+                    <EnvironmentSelect
                         value={environment}
-                        onValueChange={(v) => setEnvironment(v === "homolog" ? "homolog" : "prod")}
-                    >
-                        <SelectTrigger
-                            size="sm"
-                            className="w-auto rounded-full border-transparent bg-slate-100 px-3 text-xs font-medium text-slate-700 shadow-none hover:bg-slate-200 gap-1"
-                            aria-label="Selecionar ambiente"
-                        >
-                            <SelectValue placeholder="Ambiente" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            <SelectItem value="prod" className="focus:bg-[#3b82f6] focus:text-white">
-                                Produção
-                            </SelectItem>
-                            <SelectItem value="homolog" className="focus:bg-[#3b82f6] focus:text-white">
-                                Homologação
-                            </SelectItem>
-                        </SelectContent>
-                    </Select>
+                        onChange={setEnvironment}
+                    />
                 </div>
 
-                <div className="mb-4">
-                    <div className="text-sm font-semibold text-[#111827] mb-2">Projeto</div>
-                    <Select
-                        value={selectedKey}
-                        onValueChange={(value) => setSelectedKey(value)}
-                    >
-                        <SelectTrigger
-                            size="sm"
-                            className="w-full"
-                            aria-label="Selecionar projeto"
-                        >
-                            <SelectValue placeholder="Selecione" />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {subprojects.map((s) => (
-                                <SelectItem
-                                    key={s.key}
-                                    value={s.key}
-                                    className="focus:bg-[#3b82f6] focus:text-white"
-                                >
-                                    {s.label}
-                                </SelectItem>
-                            ))}
-                        </SelectContent>
-                    </Select>
-                </div>
+                <SubprojectSelect
+                    value={selectedKey}
+                    onChange={setSelectedKey}
+                    subprojects={subprojects}
+                />
 
                 <JenkinsJobCard
                     title=""

--- a/src/components/dashboard/Releases/index.tsx
+++ b/src/components/dashboard/Releases/index.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import JenkinsJobCard from "@/components/dashboard/JenkinsJobCard";
+import { useJenkinsJob } from "@/hooks/useJenkinsJob";
+import { cn } from "@/lib/utils";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import type { JenkinsSubproject } from "@/types/jenkinsSubproject";
+
+const EMPTY_SUBPROJECTS: JenkinsSubproject[] = [];
+
+type Props = {
+    readonly project: string;
+    readonly subprojects?: JenkinsSubproject[];
+    readonly title?: string;
+    readonly className?: string;
+};
+
+export default function Releases({
+    title = "Lançamentos",
+    className,
+    project,
+    subprojects: subprojectsProp,
+}: Props) {
+    const subprojects = useMemo(
+        () => subprojectsProp ?? EMPTY_SUBPROJECTS,
+        [subprojectsProp]
+    );
+    const hasMultipleSubprojects = subprojects.length > 1;
+
+    const [selectedKey, setSelectedKey] = useState("");
+    const [environment, setEnvironment] = useState<"prod" | "homolog">("prod");
+
+    useEffect(() => {
+        if (!project || subprojects.length === 0) {
+            setSelectedKey("");
+            return;
+        }
+
+        if (subprojects.length === 1) {
+            setSelectedKey(subprojects[0].key);
+            return;
+        }
+
+        setSelectedKey((prev) =>
+            subprojects.some((s) => s.key === prev) ? prev : subprojects[0].key
+        );
+    }, [project, subprojects]);
+
+    const query = useJenkinsJob({
+        endpoint: "/api/zabbix/jenkins/job",
+        keyPrefix: "zabbix-jenkins-job",
+        projectName: selectedKey,
+        environment,
+    });
+
+    if (!project) {
+        return (
+            <JenkinsJobCard
+                title={title}
+                className={className}
+                projectName=""
+                query={query}
+                showEnvironmentSelect
+                environment={environment}
+                onEnvironmentChange={setEnvironment}
+            />
+        );
+    }
+
+    if (subprojects.length === 0) {
+        return (
+            <div className={cn("bg-white rounded-[5px] shadow-[3px_4px_6px_0px_rgba(0,0,0,0.1)] p-5", className)}>
+                <div className="font-bold text-[14px] text-[#111827] mb-4">{title}</div>
+                <div className="text-sm text-[#6B7280] text-center">
+                    Sem lançamentos disponíveis para este projeto.
+                </div>
+            </div>
+        );
+    }
+
+    if (hasMultipleSubprojects) {
+        return (
+            <div className={cn("bg-white rounded-[5px] shadow-[3px_4px_6px_0px_rgba(0,0,0,0.1)] p-5", className)}>
+                <div className="flex items-center justify-between mb-4">
+                    <span className="font-bold text-[14px] text-[#111827]">{title}</span>
+                    <Select
+                        value={environment}
+                        onValueChange={(v) => setEnvironment(v === "homolog" ? "homolog" : "prod")}
+                    >
+                        <SelectTrigger
+                            size="sm"
+                            className="w-auto rounded-full border-transparent bg-slate-100 px-3 text-xs font-medium text-slate-700 shadow-none hover:bg-slate-200 gap-1"
+                            aria-label="Selecionar ambiente"
+                        >
+                            <SelectValue placeholder="Ambiente" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="prod" className="focus:bg-[#3b82f6] focus:text-white">
+                                Produção
+                            </SelectItem>
+                            <SelectItem value="homolog" className="focus:bg-[#3b82f6] focus:text-white">
+                                Homologação
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                <div className="mb-4">
+                    <div className="text-sm font-semibold text-[#111827] mb-2">Projeto</div>
+                    <Select
+                        value={selectedKey}
+                        onValueChange={(value) => setSelectedKey(value)}
+                    >
+                        <SelectTrigger
+                            size="sm"
+                            className="w-full"
+                            aria-label="Selecionar projeto"
+                        >
+                            <SelectValue placeholder="Selecione" />
+                        </SelectTrigger>
+                        <SelectContent>
+                            {subprojects.map((s) => (
+                                <SelectItem
+                                    key={s.key}
+                                    value={s.key}
+                                    className="focus:bg-[#3b82f6] focus:text-white"
+                                >
+                                    {s.label}
+                                </SelectItem>
+                            ))}
+                        </SelectContent>
+                    </Select>
+                </div>
+
+                <JenkinsJobCard
+                    title=""
+                    projectName={selectedKey}
+                    query={query}
+                    emptyProjectHint="Selecione um projeto"
+                    contentOnly
+                />
+            </div>
+        );
+    }
+
+    return (
+        <JenkinsJobCard
+            title={title}
+            className={className}
+            projectName={selectedKey}
+            query={query}
+            emptyProjectHint="Selecione um projeto"
+            showEnvironmentSelect
+            environment={environment}
+            onEnvironmentChange={setEnvironment}
+        />
+    );
+}

--- a/src/components/dashboard/SubprojectSelect/index.tsx
+++ b/src/components/dashboard/SubprojectSelect/index.tsx
@@ -1,0 +1,42 @@
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import type { JenkinsSubproject } from "@/types/jenkinsSubproject";
+
+type Props = {
+    readonly value: string;
+    readonly onChange: (value: string) => void;
+    readonly subprojects: JenkinsSubproject[];
+};
+
+export function SubprojectSelect({ value, onChange, subprojects }: Props) {
+    return (
+        <div className="mb-4">
+            <div className="text-sm font-semibold text-[#111827] mb-2">Projeto</div>
+            <Select value={value} onValueChange={onChange}>
+                <SelectTrigger
+                    size="sm"
+                    className="w-full"
+                    aria-label="Selecionar projeto"
+                >
+                    <SelectValue placeholder="Selecione" />
+                </SelectTrigger>
+                <SelectContent>
+                    {subprojects.map((s) => (
+                        <SelectItem
+                            key={s.key}
+                            value={s.key}
+                            className="focus:bg-[#3b82f6] focus:text-white"
+                        >
+                            {s.label}
+                        </SelectItem>
+                    ))}
+                </SelectContent>
+            </Select>
+        </div>
+    );
+}

--- a/src/hooks/useSubprojectSelection.ts
+++ b/src/hooks/useSubprojectSelection.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo, useState } from "react";
+import type { JenkinsSubproject } from "@/types/jenkinsSubproject";
+
+const EMPTY_SUBPROJECTS: JenkinsSubproject[] = [];
+
+export function useSubprojectSelection(
+    project: string,
+    subprojectsProp?: JenkinsSubproject[]
+) {
+    const subprojects = useMemo(
+        () => subprojectsProp ?? EMPTY_SUBPROJECTS,
+        [subprojectsProp]
+    );
+    const hasMultipleSubprojects = subprojects.length > 1;
+
+    const [selectedKey, setSelectedKey] = useState("");
+
+    useEffect(() => {
+        if (!project || subprojects.length === 0) {
+            setSelectedKey("");
+            return;
+        }
+
+        if (subprojects.length === 1) {
+            setSelectedKey(subprojects[0].key);
+            return;
+        }
+
+        setSelectedKey((prev) =>
+            subprojects.some((s) => s.key === prev) ? prev : subprojects[0].key
+        );
+    }, [project, subprojects]);
+
+    return { subprojects, hasMultipleSubprojects, selectedKey, setSelectedKey };
+}


### PR DESCRIPTION
## Resumo
Restaura a seção **Lançamentos** na aba Operacional do dashboard. O card havia deixado de ser exibido quando o componente passou a renderizar **Branches e Builds** na aba Saúde do deploy. Para não alterar o card da aba Saúde do deploy, foi criado um componente dedicado `Releases`, que reaproveita o `JenkinsJobCard` e o hook `useJenkinsJob` (responsáveis por exibir a última versão publicada e a versão agendada). O card é autocontido, com seletor de ambiente próprio (Produção/Homologação) e suporte a subprojetos.

## Como testar
- Configurar `JENKINS_URL`, `JENKINS_USERNAME` e `JENKINS_API_TOKEN` no `.env.local`
- Acessar o dashboard e abrir a aba **Operacional**
- Validar o card **Lançamentos** no topo da aba, exibindo a última versão publicada e, quando houver, a versão agendada
- Selecionar projetos com um ou mais subprojetos e alternar entre Produção e Homologação para validar a atualização dos dados
- Confirmar que a aba **Saúde do deploy** permanece inalterada (card Jenkins - Branches e Builds ao lado dos indicadores SonarQube)
