### PR TITLE
Feature/151229: Criacao indicadores

### DIFF
--- a/src/app/api/azure-devops/backlog/route.ts
+++ b/src/app/api/azure-devops/backlog/route.ts
@@ -15,6 +15,7 @@ export async function GET(req: NextRequest) {
   const projectName = (searchParams.get("project_name") ?? "").trim();
   const workItemTypes = searchParams.get("work_item_types");
   const states = searchParams.get("states");
+  const iterationPaths = searchParams.get("iteration_paths");
 
   if (!projectName) {
     return NextResponse.json({ error: "project_name é obrigatório" }, { status: 400 });
@@ -25,6 +26,7 @@ export async function GET(req: NextRequest) {
     const filters: Record<string, string> = {};
     if (workItemTypes) filters.work_item_types = workItemTypes;
     if (states) filters.states = states;
+    if (iterationPaths) filters.iteration_paths = iterationPaths;
 
     const backlog = await getBacklog(projectName, filters);
     return NextResponse.json(backlog);

--- a/src/components/dashboard/AzureDevOpsBacklog/index.test.tsx
+++ b/src/components/dashboard/AzureDevOpsBacklog/index.test.tsx
@@ -4,6 +4,10 @@ import type { UseQueryResult } from "@tanstack/react-query";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("@/components/ui/skeleton", () => ({
+    Skeleton: () => <div data-testid="skeleton" />,
+}));
+
 vi.mock("@/hooks/useAzureDevOpsBacklog", () => ({
     useAzureDevOpsBacklog: vi.fn(),
 }));
@@ -49,6 +53,25 @@ function makeQuery(
         ...overrides,
     } as unknown as UseQueryResult<BacklogResponse>;
 }
+
+const sprintItems: BacklogResponse["children"] = [
+    {
+        id: 1,
+        title: "[SGP] Bug sprint 10",
+        work_item_type: "BugFix",
+        state: "New",
+        iteration_path: String.raw`SME\Sprint 10`,
+        tags: "SGP",
+    },
+    {
+        id: 2,
+        title: "[SGP] Bug sprint 9",
+        work_item_type: "HotFix",
+        state: "Active",
+        iteration_path: String.raw`SME\Sprint 9`,
+        tags: "SGP",
+    },
+];
 
 describe("<AzureDevOpsBacklog />", () => {
     beforeEach(() => {
@@ -102,24 +125,7 @@ describe("<AzureDevOpsBacklog />", () => {
         const mockData: BacklogResponse = {
             total_items: 2,
             parents: [],
-            children: [
-                {
-                    id: 1,
-                    title: "[SGP] Bug sprint 10",
-                    work_item_type: "BugFix",
-                    state: "New",
-                    iteration_path: String.raw`SME\Sprint 10`,
-                    tags: "SGP",
-                },
-                {
-                    id: 2,
-                    title: "[SGP] Bug sprint 11",
-                    work_item_type: "HotFix",
-                    state: "Active",
-                    iteration_path: String.raw`SME\Sprint 11`,
-                    tags: "SGP",
-                },
-            ],
+            children: sprintItems,
             metadata: {},
         };
 
@@ -136,24 +142,7 @@ describe("<AzureDevOpsBacklog />", () => {
         const mockData: BacklogResponse = {
             total_items: 2,
             parents: [],
-            children: [
-                {
-                    id: 1,
-                    title: "[SGP] Bug sprint 10",
-                    work_item_type: "BugFix",
-                    state: "New",
-                    iteration_path: String.raw`SME\Sprint 10`,
-                    tags: "SGP",
-                },
-                {
-                    id: 2,
-                    title: "[SGP] Bug sprint 9",
-                    work_item_type: "HotFix",
-                    state: "Active",
-                    iteration_path: String.raw`SME\Sprint 9`,
-                    tags: "SGP",
-                },
-            ],
+            children: sprintItems,
             metadata: {},
         };
 
@@ -164,9 +153,11 @@ describe("<AzureDevOpsBacklog />", () => {
         render(<AzureDevOpsBacklog project="Novo SGP" />);
 
         const select = screen.getByLabelText("Sprint:");
-        fireEvent.change(select, { target: { value: "Sprint 9" } });
+        fireEvent.change(select, {
+            target: { value: String.raw`SME\Sprint 9` },
+        });
 
-        expect(select).toHaveValue("Sprint 9");
+        expect(select).toHaveValue(String.raw`SME\Sprint 9`);
     });
 
     it("não exibe select quando não há itens para o projeto", () => {
@@ -253,5 +244,166 @@ describe("<AzureDevOpsBacklog />", () => {
         expect(
             screen.getByRole("option", { name: /Sem Sprint/ }),
         ).toBeInTheDocument();
+    });
+
+    // --- BugMetricsBar ---
+
+    it("exibe os 5 labels de métricas quando project é fornecido", () => {
+        mockUseAzureDevOpsBacklog.mockReturnValue(
+            makeQuery({
+                data: { total_items: 0, parents: [], children: [], metadata: {} },
+                isSuccess: true,
+            }),
+        );
+
+        render(<AzureDevOpsBacklog project="Novo SGP" />);
+
+        expect(screen.getByText("Bugs do Ciclo")).toBeInTheDocument();
+        expect(screen.getByText("Abertos")).toBeInTheDocument();
+        expect(screen.getByText("Em andamento")).toBeInTheDocument();
+        expect(screen.getByText("Resolvidos")).toBeInTheDocument();
+        expect(
+            screen.getByText("Tempo médio de atendimento"),
+        ).toBeInTheDocument();
+    });
+
+    it("exibe valores de bug_metrics quando presentes", () => {
+        mockUseAzureDevOpsBacklog.mockReturnValue(
+            makeQuery({
+                data: {
+                    total_items: 0,
+                    parents: [],
+                    children: [],
+                    metadata: {},
+                    bug_metrics: {
+                        total_cycle: 15,
+                        open: 5,
+                        in_progress: 3,
+                        resolved: 7,
+                        average_resolution: "2d",
+                    },
+                },
+                isSuccess: true,
+            }),
+        );
+
+        render(<AzureDevOpsBacklog project="Novo SGP" />);
+
+        expect(screen.getByText("15")).toBeInTheDocument();
+        expect(screen.getByText("5")).toBeInTheDocument();
+        expect(screen.getByText("3")).toBeInTheDocument();
+        expect(screen.getByText("7")).toBeInTheDocument();
+        expect(screen.getByText("2d")).toBeInTheDocument();
+    });
+
+    it("exibe '-' para todos os campos quando bug_metrics é undefined", () => {
+        mockUseAzureDevOpsBacklog.mockReturnValue(
+            makeQuery({
+                data: { total_items: 0, parents: [], children: [], metadata: {} },
+                isSuccess: true,
+            }),
+        );
+
+        render(<AzureDevOpsBacklog project="Novo SGP" />);
+
+        expect(screen.getAllByText("-")).toHaveLength(5);
+    });
+
+    it("exibe '-' para average_resolution quando é null", () => {
+        mockUseAzureDevOpsBacklog.mockReturnValue(
+            makeQuery({
+                data: {
+                    total_items: 0,
+                    parents: [],
+                    children: [],
+                    metadata: {},
+                    bug_metrics: {
+                        total_cycle: 10,
+                        open: 2,
+                        in_progress: 1,
+                        resolved: 7,
+                        average_resolution: null,
+                    },
+                },
+                isSuccess: true,
+            }),
+        );
+
+        render(<AzureDevOpsBacklog project="Novo SGP" />);
+
+        expect(screen.getByText("-")).toBeInTheDocument();
+        expect(screen.getByText("10")).toBeInTheDocument();
+    });
+
+    it("exibe skeletons nas métricas durante loading", () => {
+        mockUseAzureDevOpsBacklog.mockReturnValue(
+            makeQuery({ isLoading: true }),
+        );
+
+        render(<AzureDevOpsBacklog project="Novo SGP" />);
+
+        expect(screen.getAllByTestId("skeleton").length).toBeGreaterThanOrEqual(5);
+        expect(screen.queryByText("Bugs do Ciclo")).not.toBeInTheDocument();
+    });
+
+    // --- iterationPaths ---
+
+    it("chama o hook com iterationPaths ao selecionar uma sprint", () => {
+        const mockData: BacklogResponse = {
+            total_items: 2,
+            parents: [],
+            children: sprintItems,
+            metadata: {},
+        };
+
+        mockUseAzureDevOpsBacklog.mockReturnValue(
+            makeQuery({ data: mockData, isSuccess: true }),
+        );
+
+        render(<AzureDevOpsBacklog project="Novo SGP" />);
+
+        const select = screen.getByLabelText("Sprint:");
+        fireEvent.change(select, {
+            target: { value: String.raw`SME\Sprint 9` },
+        });
+
+        expect(mockUseAzureDevOpsBacklog).toHaveBeenCalledWith(
+            expect.objectContaining({
+                filters: expect.objectContaining({
+                    iterationPaths: [String.raw`SME\Sprint 9`],
+                }),
+            }),
+        );
+    });
+
+    it("chama o hook sem iterationPaths ao selecionar 'Todas as Sprints'", () => {
+        const mockData: BacklogResponse = {
+            total_items: 2,
+            parents: [],
+            children: sprintItems,
+            metadata: {},
+        };
+
+        mockUseAzureDevOpsBacklog.mockReturnValue(
+            makeQuery({ data: mockData, isSuccess: true }),
+        );
+
+        render(<AzureDevOpsBacklog project="Novo SGP" />);
+
+        const select = screen.getByLabelText("Sprint:");
+
+        // Seleciona uma sprint e depois volta para "Todas as Sprints"
+        fireEvent.change(select, {
+            target: { value: String.raw`SME\Sprint 9` },
+        });
+        fireEvent.change(select, { target: { value: "all" } });
+
+        expect(mockUseAzureDevOpsBacklog).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                filters: expect.objectContaining({
+                    iterationPaths: undefined,
+                }),
+            }),
+        );
     });
 });

--- a/src/components/dashboard/AzureDevOpsBacklog/index.tsx
+++ b/src/components/dashboard/AzureDevOpsBacklog/index.tsx
@@ -1,11 +1,54 @@
 "use client";
 
-import { useMemo, useState } from "react";
 import BacklogCard from "@/components/dashboard/BacklogCard";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useAzureDevOpsBacklog } from "@/hooks/useAzureDevOpsBacklog";
 import { cn } from "@/lib/utils";
-import type { WorkItem } from "@/types/backlog";
+import type { BugMetrics, WorkItem } from "@/types/backlog";
+import { useMemo, useRef, useState } from "react";
 import { getProjectIdentifiers, matchesBugToProject } from "./bugFilters";
+
+type BugMetricsBarProps = {
+    readonly metrics?: BugMetrics;
+    readonly isLoading: boolean;
+};
+
+const METRIC_ITEMS = [
+    { key: "total_cycle" as const, label: "Bugs do Ciclo" },
+    { key: "open" as const, label: "Abertos" },
+    { key: "in_progress" as const, label: "Em andamento" },
+    { key: "resolved" as const, label: "Resolvidos" },
+    { key: "average_resolution" as const, label: "Tempo médio de atendimento" },
+];
+
+function BugMetricsBar({ metrics, isLoading }: BugMetricsBarProps) {
+    return (
+        <div className="flex flex-1 items-stretch gap-2">
+            {METRIC_ITEMS.map(({ key, label }) => (
+                <div
+                    key={key}
+                    className="flex flex-1 flex-col items-center justify-center gap-1 bg-[#F5F5F5] px-4 py-2"
+                >
+                    {isLoading ? (
+                        <>
+                            <Skeleton className="h-6 w-10" />
+                            <Skeleton className="h-3 w-16" />
+                        </>
+                    ) : (
+                        <>
+                            <span className="text-2xl font-bold text-[#3B82F6]">
+                                {metrics ? (metrics[key] ?? "-") : "-"}
+                            </span>
+                            <span className="text-center text-xs font-normal text-[#6B7280]">
+                                {label}
+                            </span>
+                        </>
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+}
 
 type Props = {
     readonly project?: string;
@@ -24,29 +67,43 @@ function getSprintName(iterationPath?: string): string {
 
 type SprintInfo = {
     name: string;
+    iterationPath: string;
     count: number;
 };
 
 /**
  * Extrai sprints únicas dos itens com contagem, ordenadas.
+ * Armazena também o iteration_path completo para uso na requisição ao backend.
  */
 function extractSprintsWithCount(items: WorkItem[]): SprintInfo[] {
-    const sprintCounts = new Map<string, number>();
+    const sprintMap = new Map<
+        string,
+        { iterationPath: string; count: number }
+    >();
     for (const item of items) {
-        const sprintName = getSprintName(item.iteration_path);
-        sprintCounts.set(sprintName, (sprintCounts.get(sprintName) ?? 0) + 1);
+        const iterationPath = item.iteration_path ?? "";
+        const name = getSprintName(iterationPath);
+        const existing = sprintMap.get(name);
+        if (existing) {
+            existing.count += 1;
+        } else {
+            sprintMap.set(name, { iterationPath, count: 1 });
+        }
     }
 
-    const sprints: SprintInfo[] = Array.from(sprintCounts.entries()).map(([name, count]) => ({
-        name,
-        count,
-    }));
+    const sprints: SprintInfo[] = Array.from(sprintMap.entries()).map(
+        ([name, { iterationPath, count }]) => ({
+            name,
+            iterationPath,
+            count,
+        }),
+    );
 
-    // Ordena sprints (tenta ordenar numericamente se possível)
+    // Ordena sprints (tenta ordenar numericamente se possível, mais recente primeiro)
     sprints.sort((a, b) => {
         const numA = Number.parseInt(a.name.replaceAll(/\D/g, ""), 10);
         const numB = Number.parseInt(b.name.replaceAll(/\D/g, ""), 10);
-        if (!Number.isNaN(numA) && !Number.isNaN(numB)) return numB - numA; // Mais recente primeiro
+        if (!Number.isNaN(numA) && !Number.isNaN(numB)) return numB - numA;
         return a.name.localeCompare(b.name);
     });
 
@@ -54,7 +111,14 @@ function extractSprintsWithCount(items: WorkItem[]): SprintInfo[] {
 }
 
 export default function AzureDevOpsBacklog({ project, className }: Props) {
-    const [selectedSprint, setSelectedSprint] = useState<string | null>(null);
+    // Armazena o iteration_path completo da sprint selecionada (null = todas as sprints)
+    const [selectedIterationPath, setSelectedIterationPath] = useState<
+        string | null
+    >(null);
+
+    // Cache da lista de sprints extraída na primeira carga (sem filtro de sprint)
+    const cachedSprintsRef = useRef<SprintInfo[]>([]);
+    const cachedTotalRef = useRef<number>(0);
 
     const query = useAzureDevOpsBacklog({
         endpoint: "/api/azure-devops/backlog",
@@ -62,51 +126,50 @@ export default function AzureDevOpsBacklog({ project, className }: Props) {
         projectName: "SME - Sustentação",
         filters: {
             workItemTypes: ["BugFix", "HotFix"],
+            iterationPaths: selectedIterationPath
+                ? [selectedIterationPath]
+                : undefined,
         },
     });
 
-    // Primeiro filtra por projeto, depois extrai sprints e aplica filtro de sprint
-    const { filteredQuery, sprintsWithCount, activeSprint, totalItems } = useMemo(() => {
+    const { filteredQuery, sprints, totalItems } = useMemo(() => {
         if (!query.data || !project) {
-            return { filteredQuery: query, sprintsWithCount: [], activeSprint: "all", totalItems: 0 };
+            return {
+                filteredQuery: query,
+                sprints: cachedSprintsRef.current,
+                totalItems: cachedTotalRef.current,
+            };
         }
 
         const projectIdentifiers = getProjectIdentifiers(project);
-
-        // Filtra por projeto
         const filterByProject = (items: WorkItem[]) =>
-            items.filter((item) => matchesBugToProject(item, projectIdentifiers));
+            items.filter((item) =>
+                matchesBugToProject(item, projectIdentifiers),
+            );
 
-        const projectFilteredParents = filterByProject(query.data.parents);
-        const projectFilteredChildren = filterByProject(query.data.children);
-        const allProjectItems = [...projectFilteredParents, ...projectFilteredChildren];
+        const filteredParents = filterByProject(query.data.parents);
+        const filteredChildren = filterByProject(query.data.children);
+        const allProjectItems = [...filteredParents, ...filteredChildren];
 
-        // Extrai sprints disponíveis com contagem
-        const sprints = extractSprintsWithCount(allProjectItems);
-
-        // Define sprint padrão como a mais recente (primeira da lista ordenada)
-        const currentSprint = selectedSprint ?? sprints[0]?.name ?? "all";
-
-        // Filtra por sprint se selecionada
-        const filterBySprint = (items: WorkItem[]) => {
-            if (currentSprint === "all") return items;
-            return items.filter((item) => getSprintName(item.iteration_path) === currentSprint);
-        };
+        // Reconstrói lista de sprints apenas na carga sem filtro de sprint
+        if (!selectedIterationPath) {
+            cachedSprintsRef.current = extractSprintsWithCount(allProjectItems);
+            cachedTotalRef.current = allProjectItems.length;
+        }
 
         return {
             filteredQuery: {
                 ...query,
                 data: {
                     ...query.data,
-                    parents: filterBySprint(projectFilteredParents),
-                    children: filterBySprint(projectFilteredChildren),
+                    parents: filteredParents,
+                    children: filteredChildren,
                 },
             },
-            sprintsWithCount: sprints,
-            activeSprint: currentSprint,
-            totalItems: allProjectItems.length,
+            sprints: cachedSprintsRef.current,
+            totalItems: cachedTotalRef.current,
         };
-    }, [query, project, selectedSprint]);
+    }, [query, project, selectedIterationPath]);
 
     if (!project) {
         return (
@@ -121,27 +184,47 @@ export default function AzureDevOpsBacklog({ project, className }: Props) {
 
     return (
         <div className={className}>
-            {/* Filtro de Sprint */}
-            {sprintsWithCount.length > 0 && (
-                <div className="mb-4 flex items-center gap-2">
-                    <label htmlFor="sprint-filter" className="text-sm font-medium text-gray-700">
-                        Sprint:
-                    </label>
-                    <select
-                        id="sprint-filter"
-                        value={activeSprint}
-                        onChange={(e) => setSelectedSprint(e.target.value)}
-                        className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-                    >
-                        <option value="all">Todas as Sprints ({totalItems})</option>
-                        {sprintsWithCount.map((sprint) => (
-                            <option key={sprint.name} value={sprint.name}>
-                                {sprint.name} ({sprint.count})
+            <div className="mb-4 flex items-end gap-4">
+                {/* Filtro de Sprint */}
+                {sprints.length > 0 && (
+                    <div className="flex items-center gap-2">
+                        <label
+                            htmlFor="sprint-filter"
+                            className="text-sm font-medium text-gray-700"
+                        >
+                            Sprint:
+                        </label>
+                        <select
+                            id="sprint-filter"
+                            value={selectedIterationPath ?? "all"}
+                            onChange={(e) => {
+                                const val = e.target.value;
+                                setSelectedIterationPath(
+                                    val === "all" ? null : val,
+                                );
+                            }}
+                            className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        >
+                            <option value="all">
+                                Todas as Sprints ({totalItems})
                             </option>
-                        ))}
-                    </select>
-                </div>
-            )}
+                            {sprints.map((sprint) => (
+                                <option
+                                    key={sprint.iterationPath}
+                                    value={sprint.iterationPath}
+                                >
+                                    {sprint.name} ({sprint.count})
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+                )}
+
+                <BugMetricsBar
+                    metrics={query.data?.bug_metrics}
+                    isLoading={query.isLoading || query.isFetching}
+                />
+            </div>
 
             <BacklogCard
                 title=""

--- a/src/hooks/useAzureDevOpsBacklog.test.ts
+++ b/src/hooks/useAzureDevOpsBacklog.test.ts
@@ -1,0 +1,182 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAzureDevOpsBacklog } from "./useAzureDevOpsBacklog";
+
+const createWrapper = () => {
+    const Wrapper = ({ children }: { children: React.ReactNode }) => {
+        const client = new QueryClient({
+            defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+        });
+        return React.createElement(QueryClientProvider, { client }, children);
+    };
+    Wrapper.displayName = "QueryClientTestWrapper";
+    return Wrapper;
+};
+
+const mockResponse = {
+    total_items: 0,
+    parents: [],
+    children: [],
+    metadata: {},
+};
+
+beforeEach(() => {
+    vi.restoreAllMocks();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("useAzureDevOpsBacklog", () => {
+    it("não faz fetch quando projectName é vazio (enabled = false)", async () => {
+        const wrapper = createWrapper();
+        const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+        renderHook(
+            () =>
+                useAzureDevOpsBacklog({
+                    endpoint: "/api/azure-devops/backlog",
+                    keyPrefix: "test",
+                    projectName: "",
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(fetchSpy).not.toHaveBeenCalled());
+    });
+
+    it("inclui work_item_types na URL quando filtro é fornecido", async () => {
+        const wrapper = createWrapper();
+
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        } as unknown as Response);
+
+        const { result } = renderHook(
+            () =>
+                useAzureDevOpsBacklog({
+                    endpoint: "/api/azure-devops/backlog",
+                    keyPrefix: "test",
+                    projectName: "SME - Sustentação",
+                    filters: { workItemTypes: ["BugFix", "HotFix"] },
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const calledUrl = fetchSpy.mock.calls[0][0] as string;
+        expect(calledUrl).toContain("work_item_types=BugFix%2CHotFix");
+    });
+
+    it("inclui iteration_paths na URL quando iterationPaths é fornecido", async () => {
+        const wrapper = createWrapper();
+
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        } as unknown as Response);
+
+        const { result } = renderHook(
+            () =>
+                useAzureDevOpsBacklog({
+                    endpoint: "/api/azure-devops/backlog",
+                    keyPrefix: "test",
+                    projectName: "SME - Sustentação",
+                    filters: {
+                        workItemTypes: ["BugFix", "HotFix"],
+                        iterationPaths: [
+                            String.raw`SME - Sustentação\Sprint 014`,
+                        ],
+                    },
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const calledUrl = fetchSpy.mock.calls[0][0] as string;
+        const params = new URLSearchParams(calledUrl.split("?")[1]);
+        expect(params.get("iteration_paths")).toBe(
+            String.raw`SME - Sustentação\Sprint 014`,
+        );
+    });
+
+    it("não inclui iteration_paths na URL quando iterationPaths é undefined", async () => {
+        const wrapper = createWrapper();
+
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        } as unknown as Response);
+
+        const { result } = renderHook(
+            () =>
+                useAzureDevOpsBacklog({
+                    endpoint: "/api/azure-devops/backlog",
+                    keyPrefix: "test",
+                    projectName: "SME - Sustentação",
+                    filters: { workItemTypes: ["BugFix"] },
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const calledUrl = fetchSpy.mock.calls[0][0] as string;
+        expect(calledUrl).not.toContain("iteration_paths");
+    });
+
+    it("não inclui iteration_paths na URL quando iterationPaths é array vazio", async () => {
+        const wrapper = createWrapper();
+
+        const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: true,
+            json: async () => mockResponse,
+        } as unknown as Response);
+
+        const { result } = renderHook(
+            () =>
+                useAzureDevOpsBacklog({
+                    endpoint: "/api/azure-devops/backlog",
+                    keyPrefix: "test",
+                    projectName: "SME - Sustentação",
+                    filters: { iterationPaths: [] },
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+        const calledUrl = fetchSpy.mock.calls[0][0] as string;
+        expect(calledUrl).not.toContain("iteration_paths");
+    });
+
+    it("retorna erro quando res.ok === false", async () => {
+        const wrapper = createWrapper();
+
+        vi.spyOn(globalThis, "fetch").mockResolvedValue({
+            ok: false,
+            json: async () => ({}),
+        } as unknown as Response);
+
+        const { result } = renderHook(
+            () =>
+                useAzureDevOpsBacklog({
+                    endpoint: "/api/azure-devops/backlog",
+                    keyPrefix: "test",
+                    projectName: "SME - Sustentação",
+                }),
+            { wrapper },
+        );
+
+        await waitFor(() => expect(result.current.isError).toBe(true));
+        expect((result.current.error as Error).message).toBe(
+            "Falha ao buscar backlog",
+        );
+    });
+});

--- a/src/hooks/useAzureDevOpsBacklog.ts
+++ b/src/hooks/useAzureDevOpsBacklog.ts
@@ -4,6 +4,7 @@ import type { BacklogResponse } from "@/types/backlog";
 export type BacklogFilters = {
   workItemTypes?: string[];
   states?: string[];
+  iterationPaths?: string[];
 };
 
 type Options = {
@@ -33,6 +34,9 @@ export function useAzureDevOpsBacklog({
       }
       if (filters?.states?.length) {
         params.states = filters.states.join(",");
+      }
+      if (filters?.iterationPaths?.length) {
+        params.iteration_paths = filters.iterationPaths.join(",");
       }
 
       const qs = new URLSearchParams(params);

--- a/src/types/backlog.ts
+++ b/src/types/backlog.ts
@@ -20,9 +20,18 @@ export interface WorkItem {
   parent_link?: string;
 }
 
+export interface BugMetrics {
+  total_cycle: number;
+  open: number;
+  in_progress: number;
+  resolved: number;
+  average_resolution: string | null;
+}
+
 export interface BacklogResponse {
   total_items: number;
   parents: WorkItem[];
   children: WorkItem[];
+  bug_metrics?: BugMetrics;
   metadata: Record<string, unknown>;
 }


### PR DESCRIPTION
Historia: [AB#151179](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/151179) e tarefa: [AB#151229](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/151229)

### Resumo
- Exibe 5 cards de métricas na seção de Bugs do dashboard (Bugs do Ciclo, Abertos, Em andamento, Resolvidos, Tempo médio de atendimento), consumidos do novo campo bug_metrics retornado pelo backend
- Ao selecionar uma sprint no dropdown, dispara nova requisição com iteration_paths para que o backend retorne as métricas filtradas pelo ciclo escolhido
- Adiciona testes unitários cobrindo as novas funcionalidades

### Como testar

1. Acesse o dashboard e selecione um projeto na aba Operacional
2. Na seção Bugs, verifique que os 5 cards de indicadores aparecem à direita do select de sprint com os valores retornados pelo backend (Bugs do Ciclo, Abertos, Em andamento, Resolvidos, Tempo médio de atendimento)
3. Selecione uma sprint diferente no dropdown e verifique que:
4. Uma nova requisição é disparada para GET /backlog com o parâmetro iteration_paths correspondente ao ciclo selecionado (verificável no Network do DevTools)
5. Os valores dos cards atualizam para refletir as métricas do ciclo selecionado
6. Selecione Todas as Sprints e verifique que a requisição é feita sem iteration_paths e os cards mostram os totais gerais
7. Verifique o estado de carregamento: ao trocar de sprint, os cards devem exibir skeletons enquanto a requisição está em andamento
8. Caso o backend retorne average_resolution: null (ciclo sem itens resolvidos), o card Tempo médio de atendimento deve exibir -