### PR TITLE
Fix/151229: Ajustes listagem bugs

### DIFF
--- a/src/components/dashboard/AzureDevOpsBacklog/bugFilters.test.ts
+++ b/src/components/dashboard/AzureDevOpsBacklog/bugFilters.test.ts
@@ -279,6 +279,33 @@ describe("bugFilters", () => {
             const identifiers = getProjectIdentifiers("Novo SGP");
             expect(matchesBugToProject(bug, identifiers)).toBe(true);
         });
+
+        it("não faz match quando título tem [Portal SME] mas projeto é Novo SGP", () => {
+            const bug = createBug({
+                title: "[Portal SME | Acervo] Capa de documento não exibida",
+                tags: undefined,
+            });
+            const identifiers = getProjectIdentifiers("Novo SGP");
+            expect(matchesBugToProject(bug, identifiers)).toBe(false);
+        });
+
+        it("não faz match quando título tem [Intranet] mas projeto é Novo SGP", () => {
+            const bug = createBug({
+                title: "[Intranet] Seção de comentários exibe texto errado",
+                tags: undefined,
+            });
+            const identifiers = getProjectIdentifiers("Novo SGP");
+            expect(matchesBugToProject(bug, identifiers)).toBe(false);
+        });
+
+        it("bug com título genérico sem identificadores ainda aparece em todos os projetos", () => {
+            const bug = createBug({
+                title: "Sistema de login muito lento",
+                tags: undefined,
+            });
+            const identifiers = getProjectIdentifiers("Novo SGP");
+            expect(matchesBugToProject(bug, identifiers)).toBe(true);
+        });
     });
 
     describe("PROJECT_IDENTIFIERS", () => {

--- a/src/components/dashboard/AzureDevOpsBacklog/bugFilters.ts
+++ b/src/components/dashboard/AzureDevOpsBacklog/bugFilters.ts
@@ -147,7 +147,6 @@ function containsAnyKnownIdentifier(searchText: string): boolean {
 
 /**
  * Verifica se um bug pertence a um projeto baseado no título e tags.
- * Busca os identificadores do projeto em qualquer lugar do título ou das tags.
  * Bugs sem identificadores conhecidos aparecem em todos os projetos.
  */
 export function matchesBugToProject(bug: WorkItem, projectIdentifiers: string[]): boolean {
@@ -159,6 +158,16 @@ export function matchesBugToProject(bug: WorkItem, projectIdentifiers: string[])
 
     // Bugs sem título e sem tags aparecem em todos os projetos
     if (searchText.trim().length === 0) return true;
+
+    // Se o título contém identificadores explícitos (colchetes ou prefixo antes de ":" / "-"),
+    // usa SOMENTE eles para determinar o projeto. Isso evita que bugs como
+    // "[Portal SME | Acervo] ..." apareçam em todos os projetos por não estarem no mapa.
+    const titleIdentifiers = extractTitleIdentifiers(normalizedTitle);
+    if (titleIdentifiers.length > 0) {
+        return titleIdentifiers.some((extracted) =>
+            projectIdentifiers.some((projectId) => identifiersMatch(extracted, projectId))
+        );
+    }
 
     // Se o bug não contém nenhum identificador conhecido, aparece em todos os projetos
     if (!containsAnyKnownIdentifier(searchText)) return true;

--- a/src/components/dashboard/AzureDevOpsBacklog/index.test.tsx
+++ b/src/components/dashboard/AzureDevOpsBacklog/index.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import type { BacklogResponse } from "@/types/backlog";
 import type { UseQueryResult } from "@tanstack/react-query";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/components/ui/skeleton", () => ({
@@ -267,20 +267,25 @@ describe("<AzureDevOpsBacklog />", () => {
         ).toBeInTheDocument();
     });
 
-    it("exibe valores de bug_metrics quando presentes", () => {
+    it("exibe contadores calculados a partir dos itens filtrados pelo projeto", () => {
         mockUseAzureDevOpsBacklog.mockReturnValue(
             makeQuery({
                 data: {
-                    total_items: 0,
+                    total_items: 4,
                     parents: [],
-                    children: [],
+                    children: [
+                        { id: 1, title: "[SGP] Bug A", work_item_type: "BugFix", state: "New" },
+                        { id: 2, title: "[SGP] Bug B", work_item_type: "BugFix", state: "New" },
+                        { id: 3, title: "[SGP] Bug C", work_item_type: "BugFix", state: "Active" },
+                        { id: 4, title: "[SGP] Bug D", work_item_type: "HotFix", state: "Resolved" },
+                    ],
                     metadata: {},
                     bug_metrics: {
-                        total_cycle: 15,
-                        open: 5,
-                        in_progress: 3,
-                        resolved: 7,
-                        average_resolution: "2d",
+                        total_cycle: 99,
+                        open: 99,
+                        in_progress: 99,
+                        resolved: 99,
+                        average_resolution: "3d",
                     },
                 },
                 isSuccess: true,
@@ -289,14 +294,18 @@ describe("<AzureDevOpsBacklog />", () => {
 
         render(<AzureDevOpsBacklog project="Novo SGP" />);
 
-        expect(screen.getByText("15")).toBeInTheDocument();
-        expect(screen.getByText("5")).toBeInTheDocument();
-        expect(screen.getByText("3")).toBeInTheDocument();
-        expect(screen.getByText("7")).toBeInTheDocument();
-        expect(screen.getByText("2d")).toBeInTheDocument();
+        const bar = screen.getByTestId("bug-metrics-bar");
+
+        // Contadores refletem os itens filtrados (4 total, 2 abertos, 1 em andamento, 1 resolvido)
+        // e não os valores do backend (99) que incluiriam outros projetos
+        expect(within(bar).getByText("4")).toBeInTheDocument();
+        expect(within(bar).getByText("2")).toBeInTheDocument();
+        expect(within(bar).getAllByText("1")).toHaveLength(2); // in_progress e resolved
+        // average_resolution vem do backend
+        expect(within(bar).getByText("3d")).toBeInTheDocument();
     });
 
-    it("exibe '-' para todos os campos quando bug_metrics é undefined", () => {
+    it("exibe 0 nos contadores quando não há itens no projeto", () => {
         mockUseAzureDevOpsBacklog.mockReturnValue(
             makeQuery({
                 data: { total_items: 0, parents: [], children: [], metadata: {} },
@@ -306,24 +315,22 @@ describe("<AzureDevOpsBacklog />", () => {
 
         render(<AzureDevOpsBacklog project="Novo SGP" />);
 
-        expect(screen.getAllByText("-")).toHaveLength(5);
+        const bar = screen.getByTestId("bug-metrics-bar");
+        expect(within(bar).getAllByText("0")).toHaveLength(4);
+        expect(within(bar).getByText("-")).toBeInTheDocument();
     });
 
-    it("exibe '-' para average_resolution quando é null", () => {
+    it("exibe '-' para average_resolution quando é null no backend", () => {
         mockUseAzureDevOpsBacklog.mockReturnValue(
             makeQuery({
                 data: {
-                    total_items: 0,
+                    total_items: 1,
                     parents: [],
-                    children: [],
+                    children: [
+                        { id: 1, title: "[SGP] Bug A", work_item_type: "BugFix", state: "New" },
+                    ],
                     metadata: {},
-                    bug_metrics: {
-                        total_cycle: 10,
-                        open: 2,
-                        in_progress: 1,
-                        resolved: 7,
-                        average_resolution: null,
-                    },
+                    bug_metrics: { total_cycle: 1, open: 1, in_progress: 0, resolved: 0, average_resolution: null },
                 },
                 isSuccess: true,
             }),
@@ -331,8 +338,9 @@ describe("<AzureDevOpsBacklog />", () => {
 
         render(<AzureDevOpsBacklog project="Novo SGP" />);
 
-        expect(screen.getByText("-")).toBeInTheDocument();
-        expect(screen.getByText("10")).toBeInTheDocument();
+        const bar = screen.getByTestId("bug-metrics-bar");
+        expect(within(bar).getByText("-")).toBeInTheDocument();
+        expect(within(bar).getAllByText("1")).toHaveLength(2); // total_cycle e open
     });
 
     it("exibe skeletons nas métricas durante loading", () => {

--- a/src/components/dashboard/AzureDevOpsBacklog/index.tsx
+++ b/src/components/dashboard/AzureDevOpsBacklog/index.tsx
@@ -23,7 +23,7 @@ const METRIC_ITEMS = [
 
 function BugMetricsBar({ metrics, isLoading }: BugMetricsBarProps) {
     return (
-        <div className="flex flex-1 items-stretch gap-2">
+        <div data-testid="bug-metrics-bar" className="flex flex-1 items-stretch gap-2">
             {METRIC_ITEMS.map(({ key, label }) => (
                 <div
                     key={key}
@@ -54,6 +54,14 @@ type Props = {
     readonly project?: string;
     readonly className?: string;
 };
+
+function getItemStatus(state?: string): "Aberto" | "Em andamento" | "Resolvido" {
+    if (!state) return "Aberto";
+    const s = state.toLowerCase();
+    if (s.includes("resolved") || s.includes("closed") || s.includes("done") || s.includes("resolvido") || s.includes("fechado")) return "Resolvido";
+    if (s.includes("active") || s.includes("progress") || s.includes("andamento") || s.includes("ativo")) return "Em andamento";
+    return "Aberto";
+}
 
 /**
  * Extrai o nome da sprint do iteration_path.
@@ -132,12 +140,12 @@ export default function AzureDevOpsBacklog({ project, className }: Props) {
         },
     });
 
-    const { filteredQuery, sprints } = useMemo(() => {
+    const { filteredQuery, sprints, computedMetrics } = useMemo(() => {
         if (!query.data || !project) {
             return {
                 filteredQuery: query,
                 sprints: cachedSprintsRef.current,
-                totalItems: cachedTotalRef.current,
+                computedMetrics: undefined,
             };
         }
 
@@ -157,6 +165,17 @@ export default function AzureDevOpsBacklog({ project, className }: Props) {
             cachedTotalRef.current = allProjectItems.length;
         }
 
+        // Calcula contadores a partir dos itens filtrados pelo projeto para que
+        // os cards sempre reflitam exatamente o que aparece na listagem abaixo.
+        // average_resolution vem do backend pois requer cálculo de datas.
+        const computedMetrics = {
+            total_cycle: allProjectItems.length,
+            open: allProjectItems.filter((i) => getItemStatus(i.state) === "Aberto").length,
+            in_progress: allProjectItems.filter((i) => getItemStatus(i.state) === "Em andamento").length,
+            resolved: allProjectItems.filter((i) => getItemStatus(i.state) === "Resolvido").length,
+            average_resolution: query.data.bug_metrics?.average_resolution ?? null,
+        };
+
         return {
             filteredQuery: {
                 ...query,
@@ -167,7 +186,7 @@ export default function AzureDevOpsBacklog({ project, className }: Props) {
                 },
             },
             sprints: cachedSprintsRef.current,
-            totalItems: cachedTotalRef.current,
+            computedMetrics,
         };
     }, [query, project, selectedIterationPath]);
 
@@ -219,7 +238,7 @@ export default function AzureDevOpsBacklog({ project, className }: Props) {
                 )}
 
                 <BugMetricsBar
-                    metrics={query.data?.bug_metrics}
+                    metrics={computedMetrics}
                     isLoading={query.isLoading || query.isFetching}
                 />
             </div>


### PR DESCRIPTION
Historia: [AB#151179](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/151179) | Tarefa: [AB#151229](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/151229)

### Resumo
Corrige filtro de projeto na seção de Bugs: bugs com identificador explícito no título (ex: [Portal SME | Acervo], [Intranet]) passavam pelo fallback e apareciam em todos os projetos quando o identificador não estava cadastrado no mapa de projetos
Restaura cálculo client-side dos cards de indicadores: os contadores (Bugs do Ciclo, Abertos, Em andamento, Resolvidos) agora refletem exatamente os bugs exibidos na listagem do projeto selecionado, e não os valores agregados do backend que incluem todos os projetos. O Tempo médio de atendimento continua vindo do backend

### Como testar

1. Acesse o dashboard e selecione um projeto na aba Operacional (ex: Novo SGP)
2. Verificar filtro por projeto:
3. Confirme que apenas bugs com [SGP] no título ou tag SGP aparecem na listagem
4. Troque para outro projeto (ex: Intranet) e confirme que a lista muda para bugs com [Intranet]
5. Bugs com [Portal SME | Acervo] ou [Intranet] não devem aparecer ao selecionar Novo SGP
6. Verificar cards de indicadores:
Observe o número exibido em Bugs do Ciclo — deve ser igual à quantidade de cards listados abaixo
Selecione um ciclo no dropdown e confirme que os valores dos cards atualizam para refletir apenas os bugs do ciclo selecionado naquele projeto
O Tempo médio de atendimento pode divergir (calculado pelo backend considerando todo o ciclo)