### PR TITLE
Feature/152164: Estruturar login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ KEYCLOAK_GRANT_TYPE=
 KEYCLOAK_REALM=
 KEYCLOAK_URL=
 
+# Client id do Keycloak que representa a aplicação (resource_access.<client>.roles no
+# access_token), usado para identificar o perfil de acesso do usuário. Muda por
+# ambiente (ex: auto-servico-qa, auto-servico-hom, auto-servico-prod). Não confundir
+# com KEYCLOAK_CLIENT_ID, que é o client usado para autenticar (ex: AUTOSSERVICO).
+KEYCLOAK_RESOURCE_CLIENT_ID=
+
 
 
 # Squads válidas para acesso (separadas por vírgula)

--- a/src/lib/auth/strategies/index.test.ts
+++ b/src/lib/auth/strategies/index.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { loginCoreSSO, loginKeycloak } from "../strategies";
 import { AxiosError, AxiosHeaders } from "axios";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loginCoreSSO, loginKeycloak } from "../strategies";
 
 // Mocks
 vi.mock("@/lib/axios", () => ({
@@ -30,22 +30,28 @@ describe("loginCoreSSO", () => {
 
     it("lança erro se AUTENTICA_CORESSO_API_URL não definida", async () => {
         delete process.env.AUTENTICA_CORESSO_API_URL;
-        await expect(loginCoreSSO({ login: "a", senha: "b" })).rejects.toThrow(/AUTENTICA_CORESSO_API_URL/);
+        await expect(loginCoreSSO({ login: "a", senha: "b" })).rejects.toThrow(
+            /AUTENTICA_CORESSO_API_URL/,
+        );
     });
 
     it("lança erro se AUTENTICA_CORESSO_API_TOKEN não definida", async () => {
         delete process.env.AUTENTICA_CORESSO_API_TOKEN;
-        await expect(loginCoreSSO({ login: "a", senha: "b" })).rejects.toThrow(/AUTENTICA_CORESSO_API_TOKEN/);
+        await expect(loginCoreSSO({ login: "a", senha: "b" })).rejects.toThrow(
+            /AUTENTICA_CORESSO_API_TOKEN/,
+        );
     });
 
     it("retorna data em caso de sucesso", async () => {
-        vi.mocked(autenticaCoreSSO.post).mockResolvedValueOnce({ data: { status: 200, nome: "João" } });
+        vi.mocked(autenticaCoreSSO.post).mockResolvedValueOnce({
+            data: { status: 200, nome: "João" },
+        });
         const resp = await loginCoreSSO({ login: "a", senha: "b" });
         expect(resp).toEqual({ status: 200, nome: "João" });
         expect(autenticaCoreSSO.post).toHaveBeenCalledWith(
             "/autenticacao/",
             { login: "a", senha: "b" },
-            expect.objectContaining({ headers: expect.any(Object) })
+            expect.objectContaining({ headers: expect.any(Object) }),
         );
     });
 
@@ -60,12 +66,20 @@ describe("loginCoreSSO", () => {
         };
         vi.mocked(autenticaCoreSSO.post).mockRejectedValueOnce(error);
         const resp = await loginCoreSSO({ login: "a", senha: "b" });
-        expect(resp).toEqual({ status: 401, detail: "msg", operation_id: "opid" });
+        expect(resp).toEqual({
+            status: 401,
+            detail: "msg",
+            operation_id: "opid",
+        });
     });
 
     it("relança erro desconhecido", async () => {
-        vi.mocked(autenticaCoreSSO.post).mockRejectedValueOnce(new Error("outra"));
-        await expect(loginCoreSSO({ login: "a", senha: "b" })).rejects.toThrow("outra");
+        vi.mocked(autenticaCoreSSO.post).mockRejectedValueOnce(
+            new Error("outra"),
+        );
+        await expect(loginCoreSSO({ login: "a", senha: "b" })).rejects.toThrow(
+            "outra",
+        );
     });
 });
 
@@ -76,7 +90,10 @@ describe("loginKeycloak", () => {
         delete process.env.KEYCLOAK_GRANT_TYPE;
         delete process.env.KEYCLOAK_REALM;
         delete process.env.KEYCLOAK_URL;
-        await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow();
+        delete process.env.KEYCLOAK_RESOURCE_CLIENT_ID;
+        await expect(
+            loginKeycloak({ login: "a", senha: "b" }),
+        ).rejects.toThrow();
 
         // restaura para não afetar outros testes
         process.env.KEYCLOAK_CLIENT_ID = "cid";
@@ -84,27 +101,43 @@ describe("loginKeycloak", () => {
         process.env.KEYCLOAK_GRANT_TYPE = "password";
         process.env.KEYCLOAK_REALM = "realm";
         process.env.KEYCLOAK_URL = "http://kc";
+        process.env.KEYCLOAK_RESOURCE_CLIENT_ID = "auto-servico-qa";
     });
-    it("lança erro se faltar clientSecret, grantType, realm ou keycloakUrl", async () => {
+    it("lança erro se faltar clientSecret, grantType, realm, keycloakUrl ou resourceClientId", async () => {
         // clientSecret
         delete process.env.KEYCLOAK_CLIENT_SECRET;
-        await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow();
+        await expect(
+            loginKeycloak({ login: "a", senha: "b" }),
+        ).rejects.toThrow();
         process.env.KEYCLOAK_CLIENT_SECRET = "sec";
 
         // grantType
         delete process.env.KEYCLOAK_GRANT_TYPE;
-        await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow();
+        await expect(
+            loginKeycloak({ login: "a", senha: "b" }),
+        ).rejects.toThrow();
         process.env.KEYCLOAK_GRANT_TYPE = "password";
 
         // realm
         delete process.env.KEYCLOAK_REALM;
-        await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow();
+        await expect(
+            loginKeycloak({ login: "a", senha: "b" }),
+        ).rejects.toThrow();
         process.env.KEYCLOAK_REALM = "realm";
 
         // keycloakUrl
         delete process.env.KEYCLOAK_URL;
-        await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow();
+        await expect(
+            loginKeycloak({ login: "a", senha: "b" }),
+        ).rejects.toThrow();
         process.env.KEYCLOAK_URL = "http://kc";
+
+        // resourceClientId
+        delete process.env.KEYCLOAK_RESOURCE_CLIENT_ID;
+        await expect(
+            loginKeycloak({ login: "a", senha: "b" }),
+        ).rejects.toThrow();
+        process.env.KEYCLOAK_RESOURCE_CLIENT_ID = "auto-servico-qa";
     });
     const OLD_ENV = process.env;
     beforeEach(() => {
@@ -114,6 +147,7 @@ describe("loginKeycloak", () => {
         process.env.KEYCLOAK_GRANT_TYPE = "password";
         process.env.KEYCLOAK_REALM = "realm";
         process.env.KEYCLOAK_URL = "http://kc";
+        process.env.KEYCLOAK_RESOURCE_CLIENT_ID = "auto-servico-qa";
         vi.resetAllMocks();
     });
     afterEach(() => {
@@ -122,22 +156,57 @@ describe("loginKeycloak", () => {
 
     it("lança erro se faltar env obrigatória", async () => {
         delete process.env.KEYCLOAK_CLIENT_ID;
-        await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow();
+        await expect(
+            loginKeycloak({ login: "a", senha: "b" }),
+        ).rejects.toThrow();
     });
 
-    it("retorna payload verificado com assinatura válida e token em caso de sucesso", async () => {
-        vi.mocked(autenticaKeycloak.post).mockResolvedValueOnce({ data: { access_token: "tok123" } });
+    it("retorna payload verificado com assinatura válida e token em caso de sucesso, extraindo groups de resource_access", async () => {
+        vi.mocked(autenticaKeycloak.post).mockResolvedValueOnce({
+            data: { access_token: "tok123" },
+        });
         mockJwtVerify.mockResolvedValueOnce({
-            payload: { name: "Nome", preferred_username: "user", groups: ["G1"] },
+            payload: {
+                name: "Nome",
+                preferred_username: "user",
+                resource_access: {
+                    "auto-servico-qa": { roles: ["COTIC"] },
+                    "outro-client": { roles: ["IGNORAR"] },
+                },
+            },
         });
         const resp = await loginKeycloak({ login: "a", senha: "b" });
-        expect(resp).toMatchObject({ name: "Nome", preferred_username: "user", groups: ["G1"], keycloakToken: "tok123" });
+        expect(resp).toMatchObject({
+            name: "Nome",
+            preferred_username: "user",
+            groups: ["COTIC"],
+            keycloakToken: "tok123",
+        });
         expect(autenticaKeycloak.post).toHaveBeenCalledWith(
             "/realms/realm/protocol/openid-connect/token",
             expect.any(URLSearchParams),
-            expect.objectContaining({ headers: { "Content-Type": "application/x-www-form-urlencoded" } })
+            expect.objectContaining({
+                headers: {
+                    "Content-Type": "application/x-www-form-urlencoded",
+                },
+            }),
         );
         expect(mockJwtVerify).toHaveBeenCalledWith("tok123", "mock-jwks");
+    });
+
+    it("retorna groups vazio quando resource_access não possui o client configurado", async () => {
+        vi.mocked(autenticaKeycloak.post).mockResolvedValueOnce({
+            data: { access_token: "tok123" },
+        });
+        mockJwtVerify.mockResolvedValueOnce({
+            payload: {
+                name: "Nome",
+                preferred_username: "user",
+                resource_access: {},
+            },
+        });
+        const resp = await loginKeycloak({ login: "a", senha: "b" });
+        expect(resp).toMatchObject({ groups: [] });
     });
 
     it("retorna status e detail em erro AxiosError com response", async () => {
@@ -151,7 +220,11 @@ describe("loginKeycloak", () => {
         };
         vi.mocked(autenticaKeycloak.post).mockRejectedValueOnce(error);
         const resp = await loginKeycloak({ login: "a", senha: "b" });
-        expect(resp).toEqual({ status: 400, detail: "desc", operation_id: "opid" });
+        expect(resp).toEqual({
+            status: 400,
+            detail: "desc",
+            operation_id: "opid",
+        });
     });
 
     it("retorna status e detail em erro AxiosError com response.detail", async () => {
@@ -165,11 +238,19 @@ describe("loginKeycloak", () => {
         };
         vi.mocked(autenticaKeycloak.post).mockRejectedValueOnce(error);
         const resp = await loginKeycloak({ login: "a", senha: "b" });
-        expect(resp).toEqual({ status: 403, detail: "msg", operation_id: "opid2" });
+        expect(resp).toEqual({
+            status: 403,
+            detail: "msg",
+            operation_id: "opid2",
+        });
     });
 
     it("relança erro desconhecido", async () => {
-        vi.mocked(autenticaKeycloak.post).mockRejectedValueOnce(new Error("outra"));
-        await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow("outra");
+        vi.mocked(autenticaKeycloak.post).mockRejectedValueOnce(
+            new Error("outra"),
+        );
+        await expect(loginKeycloak({ login: "a", senha: "b" })).rejects.toThrow(
+            "outra",
+        );
     });
 });

--- a/src/lib/auth/strategies/index.ts
+++ b/src/lib/auth/strategies/index.ts
@@ -1,6 +1,6 @@
 import { autenticaCoreSSO, autenticaKeycloak } from "@/lib/axios";
-import { AxiosError } from "axios";
 import { LoginData, LoginResponse } from "@/types/login";
+import { AxiosError } from "axios";
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
 
 export async function loginCoreSSO(data: LoginData): Promise<LoginResponse> {
@@ -16,7 +16,9 @@ export async function loginCoreSSO(data: LoginData): Promise<LoginResponse> {
         Authorization: `Token ${token}`,
     };
     try {
-        const response = await autenticaCoreSSO.post("/autenticacao/", data, { headers });
+        const response = await autenticaCoreSSO.post("/autenticacao/", data, {
+            headers,
+        });
         return response.data;
     } catch (e) {
         if (e instanceof AxiosError && e.response) {
@@ -30,11 +32,15 @@ export async function loginCoreSSO(data: LoginData): Promise<LoginResponse> {
     }
 }
 
+type KeycloakAccessTokenPayload = JWTPayload & {
+    resource_access?: Record<string, { roles?: string[] }>;
+};
+
 async function verifyKeycloakJwt(
     token: string,
     keycloakUrl: string,
     realm: string,
-): Promise<JWTPayload> {
+): Promise<KeycloakAccessTokenPayload> {
     const jwksUrl = new URL(
         `/realms/${realm}/protocol/openid-connect/certs`,
         keycloakUrl,
@@ -57,12 +63,16 @@ export async function loginKeycloak(data: LoginData): Promise<LoginResponse> {
     if (!process.env.KEYCLOAK_REALM) {
         throw new Error("KEYCLOAK_REALM não está definida");
     }
+    if (!process.env.KEYCLOAK_RESOURCE_CLIENT_ID) {
+        throw new Error("KEYCLOAK_RESOURCE_CLIENT_ID não está definida");
+    }
 
     const keycloakUrl = process.env.KEYCLOAK_URL;
     const clientId = process.env.KEYCLOAK_CLIENT_ID;
     const grantType = process.env.KEYCLOAK_GRANT_TYPE ?? "password";
     const clientSecret = process.env.KEYCLOAK_CLIENT_SECRET;
     const realm = process.env.KEYCLOAK_REALM;
+    const resourceClientId = process.env.KEYCLOAK_RESOURCE_CLIENT_ID;
     const password = data.senha;
     const username = data.login;
 
@@ -86,17 +96,25 @@ export async function loginKeycloak(data: LoginData): Promise<LoginResponse> {
         );
 
         const accessToken = keycloakResponse.data.access_token;
-        const payload = await verifyKeycloakJwt(accessToken, keycloakUrl, realm);
+        const payload = await verifyKeycloakJwt(
+            accessToken,
+            keycloakUrl,
+            realm,
+        );
+
+        const groups = payload.resource_access?.[resourceClientId]?.roles ?? [];
 
         return {
             ...payload,
+            groups,
             keycloakToken: accessToken,
-        } as LoginResponse;
+        };
     } catch (e) {
         if (e instanceof AxiosError && e.response) {
             return {
                 status: e.response.status,
-                detail: e.response.data.error_description ?? e.response.data.detail,
+                detail:
+                    e.response.data.error_description ?? e.response.data.detail,
                 operation_id: e.response.data.operation_id,
             };
         }


### PR DESCRIPTION
Historia: [AB#152163](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/152163) | Tarefa: [AB#152164](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/152164)

### Resumo
Corrige a origem do perfil de acesso no login via Keycloak (v2): os grupos/perfis do usuário agora são extraídos de resource_access["<client>"].roles do access_token (estrutura nativa do Keycloak), em vez de um claim groups no nível raiz do JWT. Adicionada a env obrigatória KEYCLOAK_RESOURCE_CLIENT_ID (client id da aplicação no Keycloak, ex: auto-servico-qa/-hom/-prod), que é diferente do KEYCLOAK_CLIENT_ID usado para autenticar (AUTOSSERVICO).

### Como testar
1. Configure KEYCLOAK_RESOURCE_CLIENT_ID no .env.local com o client id do ambiente (ex: auto-servico-qa)
2. Faça login com um usuário que tenha role de client atribuída em auto-servico-* no Keycloak
3. Confirme que o acesso é liberado e que os perfis exibidos (áreas de acesso, squads permitidas) correspondem às roles de client do usuário, não mais a um claim groups legado
4. Teste também com a env ausente: a aplicação deve lançar erro claro (KEYCLOAK_RESOURCE_CLIENT_ID não está definida) em vez de falhar silenciosamente
5. Rodar yarn vitest run src/lib/auth — 74 testes devem passar, incluindo os novos casos de extração de resource_access e ausência do client configurado