### PR TITLE
Feature/151680: Adicionar COSERV

### DIFF
--- a/src/actions/_helpers/databaseConfig.ts
+++ b/src/actions/_helpers/databaseConfig.ts
@@ -54,6 +54,12 @@ const DATABASE_CONFIG: Record<string, DbCheckConfig[]> = {
   Sigla: [
     { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
   ],
+  "Bens Físicos": [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
+  Limpeza: [
+    { label: "PostgreSQL", hostid: "10605", key: "psql.running", dbType: "postgresql", isOk: psqlRunning },
+  ],
   "Novo SGP": [
     { label: "PostgreSQL (Escrita)", hostid: "10747", key: "psql.running", dbType: "postgresql", role: "escrita", isOk: psqlRunning },
     { label: "PostgreSQL (Leitura)", hostid: "10745", key: "psql.running", dbType: "postgresql", role: "leitura", isOk: psqlRunning },

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -119,6 +119,9 @@ export default function Dashboard() {
                             <Producao
                                 className="bg-[#F5F5F5] p-3"
                                 projectName={projectNameFrontEnd}
+                                unmonitoredLabel={
+                                    projectName ? "Sem monitoramento" : undefined
+                                }
                             />
                         </CardWrapperInfoAmbientes>
 
@@ -147,11 +150,17 @@ export default function Dashboard() {
                                 title="Fila"
                                 className="mb-5 bg-[#F5F5F5] p-3"
                                 projectName={projectNameFilasRabbitMQ}
+                                unmonitoredLabel={
+                                    projectName ? "Sem fila" : undefined
+                                }
                             />
                             <Producao
                                 title="API Service"
                                 className="bg-[#F5F5F5] p-3"
                                 projectName={projectNameBackEnd}
+                                unmonitoredLabel={
+                                    projectName ? "Sem API" : undefined
+                                }
                             />
                         </CardWrapperInfoAmbientes>
 

--- a/src/assets/icons/SidebarCoserv.tsx
+++ b/src/assets/icons/SidebarCoserv.tsx
@@ -1,0 +1,40 @@
+export default function SidebarCoserv(
+    props: Readonly<React.SVGProps<SVGSVGElement>>
+) {
+    return (
+        <svg
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+            height="24"
+            viewBox="16 16 24 24"
+            className={props.className}
+            data-testid="sidebar-coserv-icon"
+            fill="none"
+            version="1.1"
+        >
+            <path
+                d="M31 18H25C24.4477 18 24 18.4477 24 19V21C24 21.5523 24.4477 22 25 22H31C31.5523 22 32 21.5523 32 21V19C32 18.4477 31.5523 18 31 18Z"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+
+            <path
+                d="M32 20H34C34.5304 20 35.0391 20.2107 35.4142 20.5858C35.7893 20.9609 36 21.4696 36 22V36C36 36.5304 35.7893 37.0391 35.4142 37.4142C35.0391 37.7893 34.5304 38 34 38H22C21.4696 38 20.9609 37.7893 20.5858 37.4142C20.2107 37.0391 20 36.5304 20 36V22C20 21.4696 20.2107 20.9609 20.5858 20.5858C20.9609 20.2107 21.4696 20 22 20H24"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+
+            <path
+                d="M25 30L27 32L31 28"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}

--- a/src/assets/icons/sidebar-icons.test.tsx
+++ b/src/assets/icons/sidebar-icons.test.tsx
@@ -8,6 +8,7 @@ import SidebarCodae from "./SidebarCodae";
 import SidebarCogep from "./SidebarCogep";
 import SidebarCoped from "./SidebarCoped";
 import SidebarCoplan from "./SidebarCoplan";
+import SidebarCoserv from "./SidebarCoserv";
 import SidebarCotic from "./SidebarCotic";
 import SidebarEmforpef from "./SidebarEmforpef";
 import SidebarGipe from "./SidebarGipe";
@@ -41,6 +42,13 @@ const icons = [
         width: "24",
         height: "24",
         testId: "sidebar-coplan-icon",
+    },
+    {
+        name: "SidebarCoserv",
+        component: SidebarCoserv,
+        width: "24",
+        height: "24",
+        testId: "sidebar-coserv-icon",
     },
     {
         name: "SidebarCotic",

--- a/src/components/dashboard/DisponibilidadeDosAmbientes/Producao/index.tsx
+++ b/src/components/dashboard/DisponibilidadeDosAmbientes/Producao/index.tsx
@@ -7,12 +7,14 @@ type ProducaoProps = {
     readonly projectName: string;
     readonly title?: string;
     readonly className?: string;
+    readonly unmonitoredLabel?: string;
 };
 
 export default function Producao({
     title = "Produção",
     className,
     projectName,
+    unmonitoredLabel,
 }: ProducaoProps) {
     const query = useZabbixStatus({
         endpoint: "/api/zabbix/status/producao",
@@ -26,6 +28,7 @@ export default function Producao({
             className={className}
             projectName={projectName}
             query={query}
+            unmonitoredLabel={unmonitoredLabel}
         />
     );
 }

--- a/src/components/dashboard/SaudeDosServidores/Filas/index.tsx
+++ b/src/components/dashboard/SaudeDosServidores/Filas/index.tsx
@@ -7,12 +7,14 @@ type FilasProps = {
     readonly projectName: string;
     readonly title?: string;
     readonly className?: string;
+    readonly unmonitoredLabel?: string;
 };
 
 export default function Filas({
     title = "Fila",
     className,
     projectName,
+    unmonitoredLabel,
 }: FilasProps) {
     const query = useZabbixStatus({
         endpoint: "/api/zabbix/status/filas",
@@ -26,6 +28,7 @@ export default function Filas({
             className={className}
             projectName={projectName}
             query={query}
+            unmonitoredLabel={unmonitoredLabel}
         />
     );
 }

--- a/src/components/dashboard/SelectSistemas/getSistemasPorSquad.ts
+++ b/src/components/dashboard/SelectSistemas/getSistemasPorSquad.ts
@@ -47,6 +47,10 @@ const squads: Record<string, Sistema[]> = {
     COPLAN: [
         makeSistema({ id: "17", nome: "SigEscola", frontend: "PRD - PTRF - SIG Escola", backend: "PRD - PTRF - SIG Escola - API", filas: "PRD - Celery PTRF", job: "SME-SigEscola/master", azure: "COPLAN - PTRF" }),
     ],
+    COSERV: [
+        makeSistema({ id: "20", nome: "Bens Físicos", frontend: "PRD - Portal Bens Fisicos", job: "SME-BensFisicos-FrontEnd/master", azure: "COSERV" }),
+        makeSistema({ id: "21", nome: "Limpeza", frontend: "PRD - Limpeza", job: "SME-LIMPEZA-FRONTEND/master", azure: "COSERV" }),
+    ],
     COTIC: [
         makeSistema({ id: "18", nome: "Autosserviço", frontend: "PRD - AUTOSSERVICO", job: "SME-Autosservico-Frontend/master", azure: "COTIC - Auto Serviço" }),
     ],
@@ -112,6 +116,16 @@ const JENKINS_SUBPROJECTS_BY_SQUAD_PROJECT: Record<string, Record<string, Jenkin
             { label: "PTRF-FrontEnd", key: "PTRF-FrontEnd" },
         ],
     },
+    COSERV: {
+        "BENS FISICOS": [
+            { label: "SME-BensFisicos-BackEnd", key: "SME-BensFisicos-BackEnd" },
+            { label: "SME-BensFisicos-FrontEnd", key: "SME-BensFisicos-FrontEnd" },
+        ],
+        LIMPEZA: [
+            { label: "SME-LIMPEZA-BACKEND", key: "SME-LIMPEZA-BACKEND" },
+            { label: "SME-LIMPEZA-FRONTEND", key: "SME-LIMPEZA-FRONTEND" },
+        ],
+    },
     COTIC: {
         AUTOSSERVICO: [{ label: "SME-Autosservico-Frontend", key: "SME-Autosservico-Frontend" }],
     },
@@ -175,6 +189,10 @@ const SONAR_PROJECT_KEY_BY_SQUAD_PROJECT: Record<string, Record<string, string>>
     },
     COPLAN: {
         SIGESCOLA: "SME-PTRF-FrontEnd",
+    },
+    COSERV: {
+        "BENS FISICOS": "SME-BensFisicos-FrontEnd",
+        LIMPEZA: "SME-LIMPEZA-FRONTEND",
     },
     COTIC: {
         AUTOSSERVICO: "SME-Autosservico-Frontend",

--- a/src/components/dashboard/Sidebar/coordenadorias.ts
+++ b/src/components/dashboard/Sidebar/coordenadorias.ts
@@ -5,6 +5,7 @@ import SidebarCodae from "@/assets/icons/SidebarCodae";
 import SidebarCogep from "@/assets/icons/SidebarCogep";
 import SidebarCoped from "@/assets/icons/SidebarCoped";
 import SidebarCoplan from "@/assets/icons/SidebarCoplan";
+import SidebarCoserv from "@/assets/icons/SidebarCoserv";
 import SidebarCotic from "@/assets/icons/SidebarCotic";
 import SidebarEmforpef from "@/assets/icons/SidebarEmforpef";
 import SidebarGipe from "@/assets/icons/SidebarGipe";
@@ -40,6 +41,12 @@ export const COORDENADORIAS: SidebarItem[] = [
         subTitle: "Coordenadoria de Planejamento e Orçamento",
         url: "#",
         icon: SidebarCoplan,
+    },
+    {
+        title: "COSERV",
+        subTitle: "Coordenadoria de Contratos de Serviços e Fornecimento",
+        url: "#",
+        icon: SidebarCoserv,
     },
     {
         title: "COTIC",

--- a/src/components/dashboard/ZabbixStatusCard.test.tsx
+++ b/src/components/dashboard/ZabbixStatusCard.test.tsx
@@ -75,6 +75,21 @@ describe("<ZabbixStatusCard />", () => {
     expect(screen.queryByLabelText(/Status:/)).not.toBeInTheDocument();
   });
 
+  it("mostra a flag neutra quando projectName está ausente e unmonitoredLabel é informado", () => {
+    render(
+      <ZabbixStatusCard
+        title="Fila"
+        className="bg-muted p-3"
+        query={makeQuery()}
+        unmonitoredLabel="Sem fila"
+      />
+    );
+
+    expect(screen.getByText("Fila")).toBeInTheDocument();
+    expect(screen.getByLabelText("Status: Sem fila")).toBeInTheDocument();
+    expect(screen.queryByText("Selecione um projeto")).not.toBeInTheDocument();
+  });
+
   it("renderiza estado de loading (isLoading)", () => {
     render(
       <ZabbixStatusCard

--- a/src/components/dashboard/ZabbixStatusCard.tsx
+++ b/src/components/dashboard/ZabbixStatusCard.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Check, XCircle, RotateCcw } from "lucide-react";
+import { Check, XCircle, MinusCircle, RotateCcw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import type { ReactNode } from "react";
 import type { UseQueryResult } from "@tanstack/react-query";
 import type { ZabbixStatus } from "@/types/zabbix";
 
@@ -13,7 +14,30 @@ type Props = {
   readonly projectName?: string;
   readonly query: UseQueryResult<ZabbixStatus, unknown>;
   readonly emptyProjectHint?: string;
+  readonly unmonitoredLabel?: string;
 };
+
+type StatusPillProps = {
+  readonly label: string;
+  readonly icon: ReactNode;
+  readonly className: string;
+};
+
+function StatusPill({ label, icon, className }: StatusPillProps) {
+  return (
+    <div
+      className={cn(
+        "mt-3 h-6 w-full rounded-full px-2",
+        "flex items-center justify-center gap-2 text-xs font-medium",
+        className
+      )}
+      aria-label={`Status: ${label}`}
+    >
+      {icon}
+      {label}
+    </div>
+  );
+}
 
 export default function ZabbixStatusCard({
   title,
@@ -21,6 +45,7 @@ export default function ZabbixStatusCard({
   projectName,
   query,
   emptyProjectHint = "Selecione um projeto",
+  unmonitoredLabel,
 }: Props) {
   const { data, isLoading, isFetching, isError, refetch } = query;
 
@@ -28,7 +53,15 @@ export default function ZabbixStatusCard({
     return (
       <div className={cn("text-center", className)}>
         <div className="font-semibold text-xl">{title}</div>
-        <div className="text-sm text-muted-foreground">{emptyProjectHint}</div>
+        {unmonitoredLabel ? (
+          <StatusPill
+            label={unmonitoredLabel}
+            icon={<MinusCircle className="h-5 w-5" aria-hidden="true" />}
+            className="bg-gray-200 text-gray-600"
+          />
+        ) : (
+          <div className="text-sm text-muted-foreground">{emptyProjectHint}</div>
+        )}
       </div>
     );
   }
@@ -72,17 +105,17 @@ export default function ZabbixStatusCard({
       <div className="font-semibold text-xl">{title}</div>
       <div className="text-sm text-muted-foreground">{subtitle}</div>
 
-      <div
-        className={cn(
-          "mt-3 h-6 w-full rounded-full px-2",
-          "flex items-center justify-center gap-2 text-xs font-medium",
-          available ? "bg-emerald-500 text-white" : "bg-red-500 text-white"
-        )}
-        aria-label={`Status: ${available ? "Disponível" : "Indisponível"}`}
-      >
-        {available ? <Check className="h-5 w-5" aria-hidden="true" /> : <XCircle className="h-5 w-5" aria-hidden="true" />}
-        {available ? "Disponível" : "Indisponível"}
-      </div>
+      <StatusPill
+        label={available ? "Disponível" : "Indisponível"}
+        icon={
+          available ? (
+            <Check className="h-5 w-5" aria-hidden="true" />
+          ) : (
+            <XCircle className="h-5 w-5" aria-hidden="true" />
+          )
+        }
+        className={available ? "bg-emerald-500 text-white" : "bg-red-500 text-white"}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Historia: [AB#151680](https://dev.azure.com/SME-Spassu/cffdf85b-c085-431c-a4a7-56a9d0a70b05/_workitems/edit/151680)

### Resumo
Adiciona a coordenadoria COSERV (Coordenadoria de Contratos de Serviços e Fornecimento) na sidebar, com ícone próprio, posicionada entre COPLAN e COTIC. A exibição depende exclusivamente dos grupos retornados pelo Keycloak, sem liberação fixa no código

Cadastra os sistemas Bens Físicos e Limpeza: triggers do Zabbix, job do Jenkins, subprojetos de release, chave do SonarQube e banco de dados PostgreSQL (hostid 10605 / psql.running). Ambos apontam para o projeto COSERV no Azure DevOps. Nenhum dos dois possui fila

Substitui o texto "Selecione um projeto" por uma flag neutra nos cards de Disponibilidade do ambiente e Saúde do servidor (Workloads) quando o sistema selecionado não tem a trigger correspondente no Zabbix: "Sem monitoramento" em Produção, "Sem fila" em Fila e "Sem API" em API Service. A mensagem anterior sugeria uma ação inexistente para o usuário, já que o projeto estava selecionado. O ajuste vale para todas as coordenadorias e afeta 10 dos 19 sistemas (Intranet, Portal CEU, Portal Educação, Rolê Agroecológico, Escolhas, Sigla, IDEP, Autosserviço, Bens Físicos e Limpeza)

### Pré-requisito de ambiente
A variável `NEXT_PUBLIC_SQUADS_VALIDAS` precisa incluir `COSERV` nos ambientes de deploy. Sem isso, um usuário que pertença apenas à COSERV é barrado no login pelo `temPermissaoDeAcesso`, mesmo com o grupo vindo do Keycloak

### Como testar
1. Garanta que `COSERV` está em `NEXT_PUBLIC_SQUADS_VALIDAS` no `.env.local`
2. Faça login com um usuário que tenha a role COSERV no client do Autosserviço no Keycloak
3. Confirme que a COSERV aparece na sidebar, entre COPLAN e COTIC, com ícone próprio (prancheta)
4. Clique na COSERV e verifique o cabeçalho "Coordenadoria de Contratos de Serviços e Fornecimento [COSERV]"
5. Abra o select de sistemas e confirme as opções Bens Físicos e Limpeza
6. Com Bens Físicos selecionado, confirme: Disponibilidade do ambiente exibindo Produção como Disponível, Banco de dados como Disponível, e o card Saúde do servidor (Workloads) exibindo as flags cinzas "Sem fila" e "Sem API"
7. Selecione uma coordenadoria com sistema sem nenhum monitoramento (ex.: GIPE) e confirme que os três cards exibem flags neutras e que o texto "Selecione um projeto" não aparece
8. Sem nenhum sistema selecionado, o texto "Selecione um projeto" deve continuar aparecendo normalmente
9. Rodar `yarn vitest run src/components/dashboard/ZabbixStatusCard.test.tsx` — 10 testes devem passar

### Observação
A trigger `PRD - Limpeza` ainda não existe no Zabbix (apenas `PRD - Portal Bens Fisicos`). A configuração já está no código, então o card de disponibilidade da Limpeza passa a funcionar assim que a trigger for criada, sem necessidade de nova alteração
