### PR TITLE
fix: define client padrão do Keycloak para homologação

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ KEYCLOAK_URL=
 # access_token), usado para identificar o perfil de acesso do usuário. Muda por
 # ambiente (ex: auto-servico-qa, auto-servico-hom, auto-servico-prod). Não confundir
 # com KEYCLOAK_CLIENT_ID, que é o client usado para autenticar (ex: AUTOSSERVICO).
+# Quando ausente, assume auto-servico-hom.
 KEYCLOAK_RESOURCE_CLIENT_ID=
 
 

--- a/src/lib/auth/strategies/index.test.ts
+++ b/src/lib/auth/strategies/index.test.ts
@@ -103,7 +103,7 @@ describe("loginKeycloak", () => {
         process.env.KEYCLOAK_URL = "http://kc";
         process.env.KEYCLOAK_RESOURCE_CLIENT_ID = "auto-servico-qa";
     });
-    it("lança erro se faltar clientSecret, grantType, realm, keycloakUrl ou resourceClientId", async () => {
+    it("lança erro se faltar clientSecret, grantType, realm ou keycloakUrl", async () => {
         // clientSecret
         delete process.env.KEYCLOAK_CLIENT_SECRET;
         await expect(
@@ -131,13 +131,6 @@ describe("loginKeycloak", () => {
             loginKeycloak({ login: "a", senha: "b" }),
         ).rejects.toThrow();
         process.env.KEYCLOAK_URL = "http://kc";
-
-        // resourceClientId
-        delete process.env.KEYCLOAK_RESOURCE_CLIENT_ID;
-        await expect(
-            loginKeycloak({ login: "a", senha: "b" }),
-        ).rejects.toThrow();
-        process.env.KEYCLOAK_RESOURCE_CLIENT_ID = "auto-servico-qa";
     });
     const OLD_ENV = process.env;
     beforeEach(() => {
@@ -192,6 +185,25 @@ describe("loginKeycloak", () => {
             }),
         );
         expect(mockJwtVerify).toHaveBeenCalledWith("tok123", "mock-jwks");
+    });
+
+    it("usa auto-servico-hom como client padrão quando KEYCLOAK_RESOURCE_CLIENT_ID está ausente", async () => {
+        delete process.env.KEYCLOAK_RESOURCE_CLIENT_ID;
+        vi.mocked(autenticaKeycloak.post).mockResolvedValueOnce({
+            data: { access_token: "tok123" },
+        });
+        mockJwtVerify.mockResolvedValueOnce({
+            payload: {
+                name: "Nome",
+                preferred_username: "user",
+                resource_access: {
+                    "auto-servico-hom": { roles: ["COTIC"] },
+                    "auto-servico-qa": { roles: ["IGNORAR"] },
+                },
+            },
+        });
+        const resp = await loginKeycloak({ login: "a", senha: "b" });
+        expect(resp).toMatchObject({ groups: ["COTIC"] });
     });
 
     it("retorna groups vazio quando resource_access não possui o client configurado", async () => {

--- a/src/lib/auth/strategies/index.ts
+++ b/src/lib/auth/strategies/index.ts
@@ -63,16 +63,14 @@ export async function loginKeycloak(data: LoginData): Promise<LoginResponse> {
     if (!process.env.KEYCLOAK_REALM) {
         throw new Error("KEYCLOAK_REALM não está definida");
     }
-    if (!process.env.KEYCLOAK_RESOURCE_CLIENT_ID) {
-        throw new Error("KEYCLOAK_RESOURCE_CLIENT_ID não está definida");
-    }
 
     const keycloakUrl = process.env.KEYCLOAK_URL;
     const clientId = process.env.KEYCLOAK_CLIENT_ID;
     const grantType = process.env.KEYCLOAK_GRANT_TYPE ?? "password";
     const clientSecret = process.env.KEYCLOAK_CLIENT_SECRET;
     const realm = process.env.KEYCLOAK_REALM;
-    const resourceClientId = process.env.KEYCLOAK_RESOURCE_CLIENT_ID;
+    const resourceClientId =
+        process.env.KEYCLOAK_RESOURCE_CLIENT_ID ?? "auto-servico-hom";
     const password = data.senha;
     const username = data.login;
 


### PR DESCRIPTION
### Resumo

Remove o `throw` de `KEYCLOAK_RESOURCE_CLIENT_ID` e passa a assumir `auto-servico-hom` quando a variável não está definida.

O ambiente de homologação ainda não foi atualizado com a variável. Sem esse padrão, `loginKeycloak` lança erro e o login fica indisponível em homolog, já que o `Dockerfile.production` fixa `NEXT_PUBLIC_AUTH_VERSION=v2`.

### Mudanças

- `src/lib/auth/strategies/index.ts`: `process.env.KEYCLOAK_RESOURCE_CLIENT_ID ?? "auto-servico-hom"`, seguindo o mesmo padrão já usado por `KEYCLOAK_GRANT_TYPE`
- `src/lib/auth/strategies/index.test.ts`: remove a asserção de erro para a variável ausente e cobre o novo padrão
- `.env.example`: documenta o valor assumido

### Pontos de atenção

- Medida paliativa. A variável precisa ser cadastrada no Rancher para cada ambiente, e o padrão removido depois.
- Enquanto o padrão existir, uma ausência da variável em produção passa despercebida: o client de homologação seria usado, `groups` viria vazio e todos os usuários seriam barrados por falta de permissão.
- O mesmo ajuste precisa ser aplicado na `test`, senão o próximo merge de `test` para `homolog` reverte o padrão.